### PR TITLE
feat: stack edit panel below item row

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -255,12 +255,19 @@ table.discogs-results thead th {
 
 .inventory-item {
   display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
+  flex-direction: column;
+  align-items: stretch;
   border: 1px solid var(--color-border);
   border-radius: 6px;
   background: var(--color-bg);
+  overflow: hidden;
+}
+
+.item-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
 }
 
 .item-badges {
@@ -349,4 +356,108 @@ table.discogs-results thead th {
   border-color: var(--color-danger-border);
 }
 
+/* Edit item panel (stacked below item row) */
+.edit-item-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.edit-item-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.edit-item-panel input[type='text'],
+.edit-item-panel input[type='search'],
+.edit-item-panel textarea {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-family: var(--sans);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.edit-item-panel textarea {
+  resize: vertical;
+  min-height: 4rem;
+}
+
+.edit-item-panel ul.discogs-results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.discogs-result-btn {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.875rem;
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.edit-item-panel ul.discogs-results li:last-child .discogs-result-btn {
+  border-bottom: none;
+}
+
+.discogs-result-btn:hover {
+  background: var(--color-row-hover-bg);
+  color: var(--color-row-hover-text);
+}
+
+.result-title {
+  flex: 1;
+}
+
+.result-meta {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+.selected-pressing {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.375rem 0.5rem;
+}
+
+.clear-pressing-btn {
+  margin-left: auto;
+  padding: 0.125rem 0.375rem;
+  background: transparent;
+  border: none;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.edit-actions {
+  display: flex;
+  gap: 0.5rem;
+}
 

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -369,53 +369,55 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           <ul className="inventory-list">
             {items.map(item => (
               <li key={item.id} className="inventory-item">
-                <div className="item-badges">
-                  <span className={`collection-badge ${item.collection_type.toLowerCase()}`}>
-                    {item.collection_type}
-                  </span>
-                  <span className="status-badge">{item.status}</span>
-                </div>
-                <div className="item-detail">
-                  {item.pressing && (
-                    <span className="item-pressing">
-                      {item.pressing.title ?? '—'}
-                      {item.pressing.artists_sort && ` · ${item.pressing.artists_sort}`}
-                      {item.pressing.year != null && ` (${item.pressing.year})`}
-                      {item.pressing.country && ` · ${item.pressing.country}`}
+                <div className="item-row">
+                  <div className="item-badges">
+                    <span className={`collection-badge ${item.collection_type.toLowerCase()}`}>
+                      {item.collection_type}
                     </span>
+                    <span className="status-badge">{item.status}</span>
+                  </div>
+                  <div className="item-detail">
+                    {item.pressing && (
+                      <span className="item-pressing">
+                        {item.pressing.title ?? '—'}
+                        {item.pressing.artists_sort && ` · ${item.pressing.artists_sort}`}
+                        {item.pressing.year != null && ` (${item.pressing.year})`}
+                        {item.pressing.country && ` · ${item.pressing.country}`}
+                      </span>
+                    )}
+                    {item.condition_media && (
+                      <span>Media: {item.condition_media}</span>
+                    )}
+                    {item.condition_sleeve && (
+                      <span>Sleeve: {item.condition_sleeve}</span>
+                    )}
+                    {item.notes && (
+                      <span className="item-notes">{item.notes}</span>
+                    )}
+                    <span className="item-date">
+                      Added {new Date(item.created_at).toLocaleDateString()}
+                    </span>
+                  </div>
+                  {isAdmin && (
+                    <button
+                      className="edit-btn"
+                      onClick={() =>
+                        setEditingItemId(id => (id === item.id ? null : item.id))
+                      }
+                      aria-label="Edit item"
+                    >
+                      ✎
+                    </button>
                   )}
-                  {item.condition_media && (
-                    <span>Media: {item.condition_media}</span>
-                  )}
-                  {item.condition_sleeve && (
-                    <span>Sleeve: {item.condition_sleeve}</span>
-                  )}
-                  {item.notes && (
-                    <span className="item-notes">{item.notes}</span>
-                  )}
-                  <span className="item-date">
-                    Added {new Date(item.created_at).toLocaleDateString()}
-                  </span>
-                </div>
-                {isAdmin && (
                   <button
-                    className="edit-btn"
-                    onClick={() =>
-                      setEditingItemId(id => (id === item.id ? null : item.id))
-                    }
-                    aria-label="Edit item"
+                    className="delete-btn"
+                    onClick={() => void handleDelete(item.id)}
+                    aria-label="Delete item"
+                    hidden={!isAdmin}
                   >
-                    ✎
+                    ×
                   </button>
-                )}
-                <button
-                  className="delete-btn"
-                  onClick={() => void handleDelete(item.id)}
-                  aria-label="Delete item"
-                  hidden={!isAdmin}
-                >
-                  ×
-                </button>
+                </div>
                 {editingItemId === item.id && (
                   <EditItemPanel
                     item={item}


### PR DESCRIPTION
## Summary

Restructure the inventory item layout so the edit panel stacks full-width below the item row instead of rendering as an inline flex sibling.

## Why

`EditItemPanel` was a direct flex child of `.inventory-item` alongside badges, detail, and action buttons. At any width it tried to squeeze into the same horizontal row, overflowing or collapsing the item content. This made the form unusable at narrower widths and was visually broken at desktop too.

## Changes

### `ui/src/pages/InventoryPage.tsx`
- Wrapped item-badges, item-detail, edit-btn, and delete-btn in a new `<div className="item-row">`
- `EditItemPanel` is now a sibling of `.item-row` inside `<li>`, rendered below the row

### `ui/src/App.css`
- `.inventory-item`: changed to `flex-direction: column; align-items: stretch; overflow: hidden; padding: 0`
- Added `.item-row`: preserves the original horizontal flex layout (`display: flex; align-items: center; gap: 1rem; padding: 0.75rem 1rem`)
- Added `.edit-item-panel`: full-width column form container with surface background and top border separator
- Added form field styles scoped to `.edit-item-panel`: `label`, `input[type='text']`, `input[type='search']`, `textarea`
- Added `.edit-item-panel ul.discogs-results`, `.discogs-result-btn`, `.result-title`, `.result-meta`
- Added `.selected-pressing`, `.clear-pressing-btn`, `.edit-actions`

## Validation

- 37/37 unit tests passing
- No behavioral changes — layout and styling only

## Risks and follow-ups

- Unit 3 (mobile-first breakpoints) is the next PR in this theme
- Visual verification required after deploy
