### PR TITLE
feat: add mobile-first responsive breakpoints (≤639px)

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -483,6 +483,7 @@ table.discogs-results thead th {
 
   .acquire-form {
     flex-direction: column;
+    align-items: stretch;
   }
 
   .acquire-form label {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -461,3 +461,56 @@ table.discogs-results thead th {
   gap: 0.5rem;
 }
 
+/* ── Mobile breakpoint (≤639px — portrait phones) ─────────────────────── */
+@media (max-width: 639px) {
+  .app-header {
+    padding: 0 1rem;
+  }
+
+  .app-content {
+    padding: 1rem;
+  }
+
+  .inventory-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .summary-counts {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .acquire-form {
+    flex-direction: column;
+  }
+
+  .acquire-form label {
+    width: 100%;
+  }
+
+  .acquire-form select,
+  .acquire-form input[type='number'],
+  .acquire-form input[type='search'] {
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  /* Hide Country + Label columns on narrow screens — Title and Year are sufficient */
+  table.discogs-results thead th:nth-child(3),
+  table.discogs-results thead th:nth-child(4),
+  table.discogs-results tbody td:nth-child(3),
+  table.discogs-results tbody td:nth-child(4) {
+    display: none;
+  }
+
+  .item-row {
+    gap: 0.5rem;
+  }
+
+  .item-badges {
+    min-width: 70px;
+  }
+}
+


### PR DESCRIPTION
## Summary

Add a `@media (max-width: 639px)` breakpoint block to `App.css` covering portrait phones (iPhone SE 375px through iPhone Pro Max 430px).

## Why

All three units of the UI redesign were planned together. Units 1 and 2 established a clean token system and stacked edit panel. Unit 3 (this PR) adds the mobile layout pass — previously the app had no responsive breakpoints at all, so on narrow screens the toolbar overflowed, the acquire form's inputs clipped at their 140px `min-width`, and the Discogs results table exceeded the viewport.

## Changes

`ui/src/App.css` — single `@media (max-width: 639px)` block:

- **`.app-header`**: padding reduced from `0 1.5rem` → `0 1rem`
- **`.app-content`**: padding reduced from `2rem 1.5rem` → `1rem`
- **`.inventory-toolbar`**: stacks to `flex-direction: column; align-items: stretch` so the title/counts and Acquire button each take full width
- **`.summary-counts`**: `flex-wrap: wrap; gap: 0.5rem` prevents count row overflow
- **`.acquire-form`**: `flex-direction: column` — inputs stack vertically rather than wrapping mid-row
- **`.acquire-form label`**: `width: 100%`
- **`.acquire-form` inputs/select**: `min-width: 0; width: 100%; box-sizing: border-box` — removes the desktop `min-width: 140px` that caused horizontal overflow
- **Discogs results table**: Country and Label columns hidden (`display: none`) on mobile — Title and Year are sufficient for selection on a narrow screen
- **`.item-row`**: gap reduced to `0.5rem`
- **`.item-badges`**: `min-width` reduced from `90px` to `70px` to give more room to the item detail text

## Validation

- 37/37 unit tests passing
- CSS-only change; visual verification required after deploy

## Risks and follow-ups

- Visual verification on device required post-deploy (iPhone SE + iPhone 15 Pro Max)
- No automated visual regression tests — noted as a testing gap (axe-core / visual testing deferred)
- This completes the three-unit UI redesign series (PRs #49, #50, #51)
