### PR TITLE
feat: show catalog number and matrix in search results and inventory

### DIFF
--- a/app/models/pressing.py
+++ b/app/models/pressing.py
@@ -43,8 +43,9 @@ class Pressing(Base):
     )
 
     # Discogs identity and linkage — lean bookmark only.
-    # All detail data (tracks, images, credits, market signals) is fetched
-    # on demand from the Discogs API and is never stored locally.
+    # Heavyweight detail (tracks, images, credits, market signals) is fetched
+    # on demand and not stored. Lightweight pressing-level detail that aids
+    # identification (catalog_number, matrix) is persisted locally.
     discogs_release_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     discogs_resource_url: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/app/models/pressing.py
+++ b/app/models/pressing.py
@@ -53,6 +53,8 @@ class Pressing(Base):
     artists_sort: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
     year: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     country: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
+    catalog_number: Mapped[str | None] = mapped_column(Text, nullable=True)
+    matrix: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     items: Mapped[list["InventoryItem"]] = relationship(back_populates="pressing")

--- a/app/schemas/discogs.py
+++ b/app/schemas/discogs.py
@@ -20,3 +20,5 @@ class DiscogsPressingIn(BaseModel):
     artists_sort: str | None = None
     year: int | None = None
     country: str | None = None
+    catalog_number: str | None = None
+    matrix: str | None = None

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -42,6 +42,8 @@ class PressingResponse(BaseModel):
     artists_sort: str | None
     year: int | None
     country: str | None
+    catalog_number: str | None
+    matrix: str | None
 
 
 class InventoryItemResponse(BaseModel):

--- a/app/services/pressing.py
+++ b/app/services/pressing.py
@@ -40,8 +40,8 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             artists_sort         = EXCLUDED.artists_sort,
             year                 = EXCLUDED.year,
             country              = EXCLUDED.country,
-            catalog_number       = EXCLUDED.catalog_number,
-            matrix               = EXCLUDED.matrix
+            catalog_number       = COALESCE(EXCLUDED.catalog_number, pressing.catalog_number),
+            matrix               = COALESCE(EXCLUDED.matrix, pressing.matrix)
         RETURNING id
         """
     )

--- a/app/services/pressing.py
+++ b/app/services/pressing.py
@@ -27,9 +27,11 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
     stmt = text(
         """
         INSERT INTO pressing
-            (discogs_release_id, discogs_resource_url, title, artists_sort, year, country)
+            (discogs_release_id, discogs_resource_url, title, artists_sort, year, country,
+             catalog_number, matrix)
         VALUES
-            (:discogs_release_id, :discogs_resource_url, :title, :artists_sort, :year, :country)
+            (:discogs_release_id, :discogs_resource_url, :title, :artists_sort, :year, :country,
+             :catalog_number, :matrix)
         ON CONFLICT (discogs_release_id)
         WHERE discogs_release_id IS NOT NULL
         DO UPDATE SET
@@ -37,7 +39,9 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             title                = EXCLUDED.title,
             artists_sort         = EXCLUDED.artists_sort,
             year                 = EXCLUDED.year,
-            country              = EXCLUDED.country
+            country              = EXCLUDED.country,
+            catalog_number       = EXCLUDED.catalog_number,
+            matrix               = EXCLUDED.matrix
         RETURNING id
         """
     )
@@ -50,6 +54,8 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             "artists_sort": pressing_in.artists_sort,
             "year": pressing_in.year,
             "country": pressing_in.country,
+            "catalog_number": pressing_in.catalog_number,
+            "matrix": pressing_in.matrix,
         },
     )
     return row.scalar_one()

--- a/migrations/versions/346f77d5b693_add_catalog_number_matrix_to_pressing.py
+++ b/migrations/versions/346f77d5b693_add_catalog_number_matrix_to_pressing.py
@@ -19,7 +19,9 @@ Both columns are TEXT NULLABLE with no index — they are display-only fields an
 are not filtered or sorted.
 
 Rollback intent:
-  Drop both columns.  No data is at risk on downgrade.
+  Drop both columns.  Any catalog_number and matrix values written after
+  this migration will be lost on downgrade; pre-existing pressing data is
+  unaffected.
 """
 
 from alembic import op

--- a/migrations/versions/346f77d5b693_add_catalog_number_matrix_to_pressing.py
+++ b/migrations/versions/346f77d5b693_add_catalog_number_matrix_to_pressing.py
@@ -1,0 +1,42 @@
+"""Add catalog_number and matrix columns to pressing
+
+Revision ID: 346f77d5b693
+Revises: dcd582777257
+Create Date: 2026-04-08
+
+Schema notes:
+- catalog_number: the Discogs catalog number (catno) supplied by the label for
+  this pressing (e.g. "RCA PB 9693").  Populated from the search-result catno
+  field at acquire/re-link time.  Nullable: not all releases carry a catalog
+  number, and older bookmarks were created before this column existed.
+- matrix: one or more matrix / runout strings, joined by " / " when multiple
+  sides are present (e.g. "YEX 773-1 HAGG / YEX 774-1 HAGG").  Populated from
+  the Discogs release identifiers array at selection time.  Nullable: matrix is
+  a nice-to-have; the field is empty when the detail fetch was skipped or when
+  the Discogs release contains no Matrix / Runout identifiers.
+
+Both columns are TEXT NULLABLE with no index — they are display-only fields and
+are not filtered or sorted.
+
+Rollback intent:
+  Drop both columns.  No data is at risk on downgrade.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "346f77d5b693"  # pragma: allowlist secret
+down_revision = "dcd582777257"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pressing", sa.Column("catalog_number", sa.Text(), nullable=True))
+    op.add_column("pressing", sa.Column("matrix", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pressing", "matrix")
+    op.drop_column("pressing", "catalog_number")

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -621,6 +621,8 @@ class TestPressingService:
             artists_sort="Astley, Rick",
             year=1987,
             country="UK",
+            catalog_number="RCA PB 9693",
+            matrix="YEX 773-1 HAGG",
         )
 
     def test_upsert_pressing_executes_insert_on_conflict(self) -> None:
@@ -658,6 +660,8 @@ class TestPressingService:
         assert params["artists_sort"] == pressing_in.artists_sort
         assert params["year"] == pressing_in.year
         assert params["country"] == pressing_in.country
+        assert params["catalog_number"] == pressing_in.catalog_number
+        assert params["matrix"] == pressing_in.matrix
 
     def test_upsert_pressing_returns_scalar_uuid(self) -> None:
         """upsert_pressing() propagates scalar_one() directly to the caller."""

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -498,11 +498,13 @@ table.discogs-results thead th {
     box-sizing: border-box;
   }
 
-  /* Hide Country + Label columns on narrow screens — Title and Year are sufficient */
+  /* Hide Country, Label, and Catalog columns on narrow screens — Title and Year are sufficient */
   table.discogs-results thead th:nth-child(3),
   table.discogs-results thead th:nth-child(4),
+  table.discogs-results thead th:nth-child(5),
   table.discogs-results tbody td:nth-child(3),
-  table.discogs-results tbody td:nth-child(4) {
+  table.discogs-results tbody td:nth-child(4),
+  table.discogs-results tbody td:nth-child(5) {
     display: none;
   }
 

--- a/ui/src/api/discogs.ts
+++ b/ui/src/api/discogs.ts
@@ -9,6 +9,7 @@ export interface DiscogsSearchResult {
   thumb?: string
   label?: string[]
   format?: string[]
+  catno?: string
 }
 
 export interface DiscogsSearchResponse {
@@ -31,6 +32,7 @@ export interface DiscogsRelease {
   resource_url?: string
   tracklist?: unknown[]
   images?: unknown[]
+  identifiers?: { type: string; value: string; description?: string }[]
   [key: string]: unknown
 }
 

--- a/ui/src/api/inventory.test.ts
+++ b/ui/src/api/inventory.test.ts
@@ -163,6 +163,8 @@ describe('updateItem', () => {
       artists_sort: null,
       year: 1987,
       country: 'UK',
+      catalog_number: null,
+      matrix: null,
     }
     await updateItem('item-1', { pressing })
     const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -8,6 +8,8 @@ export interface PressingBookmark {
   artists_sort: string | null
   year: number | null
   country: string | null
+  catalog_number: string | null
+  matrix: string | null
 }
 
 export interface InventoryItem {
@@ -37,6 +39,8 @@ export interface DiscogsPressingIn {
   artists_sort: string | null
   year: number | null
   country: string | null
+  catalog_number: string | null
+  matrix: string | null
 }
 
 export interface AcquireRequest {

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -157,6 +157,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           {selectedPressing.year != null && ` (${selectedPressing.year})`}
           {selectedPressing.country && ` · ${selectedPressing.country}`}
           {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
+          {selectedPressing.matrix && ` · Matrix: ${selectedPressing.matrix}`}
           <button
             type="button"
             className="clear-pressing-btn"

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -81,14 +81,18 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
     setDiscogsQuery(result.title)
 
     // Best-effort: fetch full release to populate matrix.
-    getDiscogsRelease(result.id)
+    // Gate on releaseId so a stale promise cannot overwrite a newer selection.
+    const releaseId = result.id
+    getDiscogsRelease(releaseId)
       .then(release => {
         const matrix = release.identifiers
           ?.filter(i => i.type === 'Matrix / Runout')
           .map(i => i.value)
           .join(' / ') || null
         if (matrix && isMounted.current) {
-          setSelectedPressing(p => p ? { ...p, matrix } : p)
+          setSelectedPressing(p =>
+            p && p.discogs_release_id === releaseId ? { ...p, matrix } : p
+          )
         }
       })
       .catch(() => { /* matrix stays null — non-critical */ })

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { searchDiscogs, type DiscogsSearchResult } from '../api/discogs'
+import { searchDiscogs, getDiscogsRelease, type DiscogsSearchResult } from '../api/discogs'
 import { updateItem, type DiscogsPressingIn, type InventoryItem, type UpdateRequest } from '../api/inventory'
 
 interface Props {
@@ -73,10 +73,25 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
       artists_sort: null,
       year: result.year != null ? Number(result.year) : null,
       country: result.country ?? null,
+      catalog_number: result.catno ?? null,
+      matrix: null,
     }
     setSelectedPressing(pressing)
     setDiscogsResults([])
     setDiscogsQuery(result.title)
+
+    // Best-effort: fetch full release to populate matrix.
+    getDiscogsRelease(result.id)
+      .then(release => {
+        const matrix = release.identifiers
+          ?.filter(i => i.type === 'Matrix / Runout')
+          .map(i => i.value)
+          .join(' / ') || null
+        if (matrix && isMounted.current) {
+          setSelectedPressing(p => p ? { ...p, matrix } : p)
+        }
+      })
+      .catch(() => { /* matrix stays null — non-critical */ })
   }
 
   async function handleSave() {
@@ -137,6 +152,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           <strong>New pressing:</strong> {selectedPressing.title}
           {selectedPressing.year != null && ` (${selectedPressing.year})`}
           {selectedPressing.country && ` · ${selectedPressing.country}`}
+          {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
           <button
             type="button"
             className="clear-pressing-btn"

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -22,6 +22,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchSeq = useRef(0)
   const isMounted = useRef(true)
+  const matrixFetch = useRef<Promise<void> | null>(null)
 
   useEffect(() => {
     return () => {
@@ -83,7 +84,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
     // Best-effort: fetch full release to populate matrix.
     // Gate on releaseId so a stale promise cannot overwrite a newer selection.
     const releaseId = result.id
-    getDiscogsRelease(releaseId)
+    matrixFetch.current = getDiscogsRelease(releaseId)
       .then(release => {
         const matrix = release.identifiers
           ?.filter(i => i.type === 'Matrix / Runout')
@@ -99,6 +100,12 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   }
 
   async function handleSave() {
+    // Await any in-flight matrix fetch so the pressing payload includes matrix
+    // if the user saves before the best-effort detail request has resolved.
+    if (matrixFetch.current) {
+      await matrixFetch.current
+      matrixFetch.current = null
+    }
     setSaving(true)
     setSaveError(null)
     try {

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -100,15 +100,16 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   }
 
   async function handleSave() {
-    // Await any in-flight matrix fetch so the pressing payload includes matrix
-    // if the user saves before the best-effort detail request has resolved.
-    if (matrixFetch.current) {
-      await matrixFetch.current
-      matrixFetch.current = null
-    }
+    if (saving) return
     setSaving(true)
     setSaveError(null)
     try {
+      // Await any in-flight matrix fetch so the pressing payload includes matrix
+      // if the user saves before the best-effort detail request has resolved.
+      if (matrixFetch.current) {
+        await matrixFetch.current
+        matrixFetch.current = null
+      }
       const request: UpdateRequest = {
         ...(selectedPressing ? { pressing: selectedPressing } : {}),
         condition_media: conditionMedia || null,

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -27,12 +27,14 @@ vi.mock('../api/inventory', () => ({
 // Mock the Discogs API module
 vi.mock('../api/discogs', () => ({
   searchDiscogs: vi.fn(),
+  getDiscogsRelease: vi.fn(),
 }))
 
 import * as inventoryApi from '../api/inventory'
 import * as discogsApi from '../api/discogs'
 
 const mockSearchDiscogs = vi.mocked(discogsApi.searchDiscogs)
+const mockGetDiscogsRelease = vi.mocked(discogsApi.getDiscogsRelease)
 const mockListItems = vi.mocked(inventoryApi.listItems)
 const mockGetSummary = vi.mocked(inventoryApi.getSummary)
 const mockAcquireItems = vi.mocked(inventoryApi.acquireItems)
@@ -74,6 +76,8 @@ beforeEach(() => {
     results: [],
     pagination: { page: 1, pages: 0, per_page: 50, items: 0, urls: {} },
   })
+  // By default resolve with no matrix identifiers so existing tests are unaffected
+  mockGetDiscogsRelease.mockResolvedValue({ id: 0, title: '', identifiers: [] })
 })
 
 function renderPage() {
@@ -212,6 +216,7 @@ const sampleDiscogsResult = {
   year: '1987',
   country: 'UK',
   resource_url: 'https://api.discogs.com/releases/249504',
+  catno: 'RCA PB 9693',
 }
 
 async function openAcquireForm() {
@@ -261,6 +266,7 @@ describe('InventoryPage — Discogs search-and-select', () => {
     const req = mockAcquireItems.mock.calls[0][0]
     expect(req.pressing?.discogs_release_id).toBe(249504)
     expect(req.pressing?.title).toBe('Never Gonna Give You Up')
+    expect(req.pressing?.catalog_number).toBe('RCA PB 9693')
   })
 
   it('editing the search query after selection removes pressing from the acquire request', async () => {

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -315,6 +315,56 @@ describe('InventoryPage — Discogs search-and-select', () => {
     // The search results list should never appear because reset invalidated the request
     expect(screen.queryByText('Never Gonna Give You Up')).not.toBeInTheDocument()
   })
+
+  it('populates matrix on the acquire request when getDiscogsRelease resolves with identifiers', async () => {
+    mockSearchDiscogs.mockResolvedValue({
+      results: [sampleDiscogsResult],
+      pagination: { page: 1, pages: 1, per_page: 50, items: 1, urls: {} },
+    })
+    mockGetDiscogsRelease.mockResolvedValue({
+      id: 249504,
+      title: 'Never Gonna Give You Up',
+      identifiers: [
+        { type: 'Matrix / Runout', value: 'YEX 773-1 HAGG', description: 'Side A' },
+        { type: 'Matrix / Runout', value: 'YEX 774-1 HAGG', description: 'Side B' },
+        { type: 'Barcode', value: '5 099746 350529' },
+      ],
+    })
+    await openAcquireForm()
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('Artist, title, label…'), 'Rick')
+    await waitFor(() =>
+      expect(screen.getByText('Never Gonna Give You Up')).toBeInTheDocument(),
+      { timeout: 1500 },
+    )
+    await user.click(screen.getByText('Never Gonna Give You Up'))
+
+    await user.click(screen.getByText('Confirm'))
+    await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())
+    const req = mockAcquireItems.mock.calls[0][0]
+    expect(req.pressing?.matrix).toBe('YEX 773-1 HAGG / YEX 774-1 HAGG')
+  })
+
+  it('acquire proceeds with matrix null when getDiscogsRelease rejects', async () => {
+    mockSearchDiscogs.mockResolvedValue({
+      results: [sampleDiscogsResult],
+      pagination: { page: 1, pages: 1, per_page: 50, items: 1, urls: {} },
+    })
+    mockGetDiscogsRelease.mockRejectedValue(new Error('network error'))
+    await openAcquireForm()
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('Artist, title, label…'), 'Rick')
+    await waitFor(() =>
+      expect(screen.getByText('Never Gonna Give You Up')).toBeInTheDocument(),
+      { timeout: 1500 },
+    )
+    await user.click(screen.getByText('Never Gonna Give You Up'))
+
+    await user.click(screen.getByText('Confirm'))
+    await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())
+    const req = mockAcquireItems.mock.calls[0][0]
+    expect(req.pressing?.matrix).toBeNull()
+  })
 })
 
 describe('InventoryPage — edit flow', () => {

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -260,6 +260,7 @@ describe('InventoryPage — Discogs search-and-select', () => {
     await user.click(screen.getByText('Never Gonna Give You Up'))
 
     expect(screen.getByText(/Selected:/)).toBeInTheDocument()
+    expect(screen.getByText(/RCA PB 9693/)).toBeInTheDocument()
 
     await user.click(screen.getByText('Confirm'))
     await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { InventoryPage } from './InventoryPage'
 
@@ -321,15 +321,11 @@ describe('InventoryPage — Discogs search-and-select', () => {
       results: [sampleDiscogsResult],
       pagination: { page: 1, pages: 1, per_page: 50, items: 1, urls: {} },
     })
-    mockGetDiscogsRelease.mockResolvedValue({
-      id: 249504,
-      title: 'Never Gonna Give You Up',
-      identifiers: [
-        { type: 'Matrix / Runout', value: 'YEX 773-1 HAGG', description: 'Side A' },
-        { type: 'Matrix / Runout', value: 'YEX 774-1 HAGG', description: 'Side B' },
-        { type: 'Barcode', value: '5 099746 350529' },
-      ],
-    })
+    // Use a deferred promise so we control exactly when the release fetch resolves.
+    let resolveRelease!: (v: Awaited<ReturnType<typeof discogsApi.getDiscogsRelease>>) => void
+    mockGetDiscogsRelease.mockReturnValue(
+      new Promise(res => { resolveRelease = res }),
+    )
     await openAcquireForm()
     const user = userEvent.setup()
     await user.type(screen.getByPlaceholderText('Artist, title, label…'), 'Rick')
@@ -338,6 +334,20 @@ describe('InventoryPage — Discogs search-and-select', () => {
       { timeout: 1500 },
     )
     await user.click(screen.getByText('Never Gonna Give You Up'))
+
+    // Resolve the fetch inside act() so React flushes the setAcquireForm state
+    // update before the Confirm click — prevents a race where matrix is still null.
+    await act(async () => {
+      resolveRelease({
+        id: 249504,
+        title: 'Never Gonna Give You Up',
+        identifiers: [
+          { type: 'Matrix / Runout', value: 'YEX 773-1 HAGG', description: 'Side A' },
+          { type: 'Matrix / Runout', value: 'YEX 774-1 HAGG', description: 'Side B' },
+          { type: 'Barcode', value: '5 099746 350529' },
+        ],
+      })
+    })
 
     await user.click(screen.getByText('Confirm'))
     await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -144,15 +144,23 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
 
     // Best-effort: fetch full release to populate matrix.
     // Non-blocking — pressing is already set; we update state if the fetch resolves.
-    getDiscogsRelease(result.id)
+    // Gate on releaseId so a stale promise cannot overwrite a newer selection.
+    const releaseId = result.id
+    getDiscogsRelease(releaseId)
       .then(release => {
         const matrix = release.identifiers
           ?.filter(i => i.type === 'Matrix / Runout')
           .map(i => i.value)
           .join(' / ') || null
         if (matrix) {
-          setSelectedPressing(p => p ? { ...p, matrix } : p)
-          setAcquireForm(f => f.pressing ? { ...f, pressing: { ...f.pressing, matrix } } : f)
+          setSelectedPressing(p =>
+            p && p.discogs_release_id === releaseId ? { ...p, matrix } : p
+          )
+          setAcquireForm(f =>
+            f.pressing && f.pressing.discogs_release_id === releaseId
+              ? { ...f, pressing: { ...f.pressing, matrix } }
+              : f
+          )
         }
       })
       .catch(() => { /* matrix stays null — non-critical */ })

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -11,7 +11,7 @@ import {
   type InventoryItem,
   type SummaryResponse,
 } from '../api/inventory'
-import { searchDiscogs, type DiscogsSearchResult } from '../api/discogs'
+import { searchDiscogs, getDiscogsRelease, type DiscogsSearchResult } from '../api/discogs'
 import { EditItemPanel } from '../components/EditItemPanel'
 
 interface InventoryPageProps {
@@ -134,11 +134,28 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
       artists_sort: null,
       year: result.year != null ? Number(result.year) : null,
       country: result.country ?? null,
+      catalog_number: result.catno ?? null,
+      matrix: null,
     }
     setSelectedPressing(pressing)
     setAcquireForm(f => ({ ...f, pressing }))
     setDiscogsResults([])
     setDiscogsQuery(result.title)
+
+    // Best-effort: fetch full release to populate matrix.
+    // Non-blocking — pressing is already set; we update state if the fetch resolves.
+    getDiscogsRelease(result.id)
+      .then(release => {
+        const matrix = release.identifiers
+          ?.filter(i => i.type === 'Matrix / Runout')
+          .map(i => i.value)
+          .join(' / ') || null
+        if (matrix) {
+          setSelectedPressing(p => p ? { ...p, matrix } : p)
+          setAcquireForm(f => f.pressing ? { ...f, pressing: { ...f.pressing, matrix } } : f)
+        }
+      })
+      .catch(() => { /* matrix stays null — non-critical */ })
   }
 
   function resetAcquireForm() {
@@ -249,6 +266,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                     <th scope="col">Year</th>
                     <th scope="col">Country</th>
                     <th scope="col">Label</th>
+                    <th scope="col">Catalog</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -269,6 +287,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                       <td>{r.year ?? '—'}</td>
                       <td>{r.country ?? '—'}</td>
                       <td>{r.label?.[0] ?? '—'}</td>
+                      <td>{r.catno ?? '—'}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -383,6 +402,8 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                         {item.pressing.artists_sort && ` · ${item.pressing.artists_sort}`}
                         {item.pressing.year != null && ` (${item.pressing.year})`}
                         {item.pressing.country && ` · ${item.pressing.country}`}
+                        {item.pressing.catalog_number && ` · ${item.pressing.catalog_number}`}
+                        {item.pressing.matrix && ` · ${item.pressing.matrix}`}
                       </span>
                     )}
                     {item.condition_media && (

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -307,6 +307,8 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 <strong>Selected:</strong> {selectedPressing.title}
                 {selectedPressing.year != null && ` (${selectedPressing.year})`}
                 {selectedPressing.country && ` · ${selectedPressing.country}`}
+                {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
+                {selectedPressing.matrix && ` · Matrix: ${selectedPressing.matrix}`}
                 <button
                   type="button"
                   className="clear-pressing-btn"


### PR DESCRIPTION
Closes #52

## Summary

Adds `catalog_number` and `matrix` fields to the pressing schema, database, and UI, surfacing label catalog numbers and matrix/runout strings alongside existing pressing metadata.

## Why

Catalog numbers are how collectors identify pressings ("RCA PB 9693" is more specific than "UK 1987"). Matrix strings give additional pressing-level detail often used to distinguish between stampers, cut revisions, and regional variants.

## Changes

**Database**
- New migration `346f77d5b693`: adds `catalog_number TEXT` and `matrix TEXT` (both nullable) to the `pressing` table.

**Backend**
- `app/models/pressing.py` — two new mapped columns.
- `app/schemas/discogs.py` — `DiscogsPressingIn` gains `catalog_number` and `matrix` (both nullable, default `None`).
- `app/schemas/inventory.py` — `PressingResponse` exposes both fields.
- `app/services/pressing.py` — SQL upsert covers both columns in `INSERT` and `DO UPDATE SET`.

**Frontend types**
- `ui/src/api/discogs.ts` — `DiscogsSearchResult` gains `catno?: string`; `DiscogsRelease` gains typed `identifiers` array.
- `ui/src/api/inventory.ts` — `PressingBookmark` and `DiscogsPressingIn` gain `catalog_number` and `matrix`.

**UI**
- `InventoryPage.tsx` — Catalog column added to Discogs search results table; `handleSelectResult` populates `catalog_number` from `result.catno` and triggers a non-blocking `getDiscogsRelease()` call to extract matrix from the `identifiers` array (matrix is a nice-to-have: failure is silent, pressing is still selected immediately with catno). Inventory item detail shows catalog number and matrix when present.
- `EditItemPanel.tsx` — same catno + non-blocking matrix enrichment at re-link selection; selected pressing chip shows catalog number.
- `App.css` — mobile breakpoint (≤639px) now hides the new Catalog column (column 5) alongside Country and Label.

## Validation

- 37/37 Vitest tests pass (including updated `sampleDiscogsResult` with `catno`, catalog_number assertion in acquire payload test, and `getDiscogsRelease` mock).
- `tsc -b && vite build` clean.

## Risks and follow-ups

- Matrix fetch adds one Discogs API call per selection (~200–500 ms). The call is non-blocking — the pressing chip appears immediately with the catalog number; matrix populates asynchronously if the fetch resolves. Failure is swallowed silently.
- Existing pressing rows will have `NULL` in both columns until re-acquired or re-linked from the UI. No backfill is planned.
- CSS/visual column layout has no automated test coverage — consistent with prior PRs in this series.
