### PR TITLE
fix: restructure selected-pressing tile to wrap matrix on its own line

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -436,7 +436,7 @@ table.discogs-results thead th {
 
 .selected-pressing {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   font-size: 0.875rem;
   color: var(--color-text);
@@ -444,6 +444,26 @@ table.discogs-results thead th {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   padding: 0.375rem 0.5rem;
+}
+
+.selected-pressing-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.selected-pressing-title {
+  line-height: 1.4;
+}
+
+.selected-pressing-matrix {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  overflow-wrap: break-word;
+  word-break: break-word;
+  line-height: 1.4;
 }
 
 .clear-pressing-btn {

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -161,11 +161,17 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
 
       {selectedPressing && (
         <div className="selected-pressing">
-          <strong>New pressing:</strong> {selectedPressing.title}
-          {selectedPressing.year != null && ` (${selectedPressing.year})`}
-          {selectedPressing.country && ` · ${selectedPressing.country}`}
-          {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
-          {selectedPressing.matrix && ` · Matrix: ${selectedPressing.matrix}`}
+          <div className="selected-pressing-info">
+            <span className="selected-pressing-title">
+              <strong>New pressing:</strong> {selectedPressing.title}
+              {selectedPressing.year != null && ` (${selectedPressing.year})`}
+              {selectedPressing.country && ` · ${selectedPressing.country}`}
+              {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
+            </span>
+            {selectedPressing.matrix && (
+              <span className="selected-pressing-matrix">Matrix: {selectedPressing.matrix}</span>
+            )}
+          </div>
           <button
             type="button"
             className="clear-pressing-btn"

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -304,11 +304,17 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
 
             {selectedPressing && (
               <div className="selected-pressing">
-                <strong>Selected:</strong> {selectedPressing.title}
-                {selectedPressing.year != null && ` (${selectedPressing.year})`}
-                {selectedPressing.country && ` · ${selectedPressing.country}`}
-                {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
-                {selectedPressing.matrix && ` · Matrix: ${selectedPressing.matrix}`}
+                <div className="selected-pressing-info">
+                  <span className="selected-pressing-title">
+                    <strong>Selected:</strong> {selectedPressing.title}
+                    {selectedPressing.year != null && ` (${selectedPressing.year})`}
+                    {selectedPressing.country && ` · ${selectedPressing.country}`}
+                    {selectedPressing.catalog_number && ` · ${selectedPressing.catalog_number}`}
+                  </span>
+                  {selectedPressing.matrix && (
+                    <span className="selected-pressing-matrix">Matrix: {selectedPressing.matrix}</span>
+                  )}
+                </div>
                 <button
                   type="button"
                   className="clear-pressing-btn"


### PR DESCRIPTION
## Summary

Restructure the selected-pressing confirmation tile so that the long matrix string no longer renders as one unbroken inline blob.

## Why

When a pressing has many matrix / runout identifiers (e.g. the White Album with 30+ sides), the old layout concatenated everything into a single line of text that overflowed the tile and was unreadable. The identity fields (title, year, country, catalog number) got buried in the noise.

## Changes

- `App.css` — convert `.selected-pressing` to `align-items: flex-start`; add `.selected-pressing-info` (flex-column wrapper), `.selected-pressing-title`, and `.selected-pressing-matrix` (smaller, muted, `word-break: break-word`)
- `InventoryPage.tsx` — update selected-pressing JSX to use new class structure; matrix rendered as a separate `<span>` on its own line below the identity fields
- `EditItemPanel.tsx` — same restructuring applied to the re-link panel tile

## Validation

- Visually confirmed: identity row stays compact; matrix wraps cleanly below it
- `×` button remains top-aligned regardless of matrix length
- No TypeScript errors

## Risks / Follow-ups

- None. Pure layout change — no data or API contract affected.
- Noted separately: runbook `routine-deploy.md` documents inventory smoke test as expecting `401`; actual response is `403` (FastAPI `Security()` default). Not in scope here.
