### PR TITLE
feat: replace plain h1 with SVG vinyl-record wordmark

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -14,10 +14,11 @@
   background: var(--color-bg);
 }
 
-.app-header h1 {
-  font-size: 1.25rem;
-  font-weight: 600;
+.site-wordmark {
   margin: 0;
+  line-height: 0;
+  display: flex;
+  align-items: center;
 }
 
 .sign-out {

--- a/ui/src/components/WordMark.tsx
+++ b/ui/src/components/WordMark.tsx
@@ -2,10 +2,9 @@ export function WordMark() {
   return (
     <svg
       viewBox="0 0 138 36"
-      width="138"
-      height="36"
       aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
+      style={{ height: '2.25rem', width: 'auto' }}
     >
       {/* Vinyl record body */}
       <circle cx="18" cy="18" r="17" fill="#1c1c1e" />

--- a/ui/src/components/WordMark.tsx
+++ b/ui/src/components/WordMark.tsx
@@ -1,0 +1,42 @@
+export function WordMark() {
+  return (
+    <svg
+      viewBox="0 0 138 36"
+      width="138"
+      height="36"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Vinyl record body */}
+      <circle cx="18" cy="18" r="17" fill="#1c1c1e" />
+      {/* Groove rings */}
+      <circle cx="18" cy="18" r="14" fill="none" stroke="#2e2e2e" strokeWidth="0.6" />
+      <circle cx="18" cy="18" r="11" fill="none" stroke="#2e2e2e" strokeWidth="0.6" />
+      <circle cx="18" cy="18" r="8"  fill="none" stroke="#2e2e2e" strokeWidth="0.6" />
+      {/* Center label — warm amber */}
+      <circle cx="18" cy="18" r="5.5" fill="#b8732a" />
+      {/* Center spindle hole */}
+      <circle cx="18" cy="18" r="1.5" fill="#1c1c1e" />
+      {/* "RECORD" — small, spaced, muted */}
+      <text
+        x="42"
+        y="14"
+        fontFamily="Georgia, 'Times New Roman', serif"
+        fontSize="9"
+        letterSpacing="0.22em"
+        fill="currentColor"
+        opacity="0.5"
+      >RECORD</text>
+      {/* "RANCH" — prominent */}
+      <text
+        x="42"
+        y="30"
+        fontFamily="Georgia, 'Times New Roman', serif"
+        fontSize="16"
+        letterSpacing="0.08em"
+        fill="currentColor"
+        fontWeight="700"
+      >RANCH</text>
+    </svg>
+  )
+}

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -84,6 +84,17 @@ function renderPage() {
   return render(<InventoryPage user={mockUser} signOut={mockSignOut} />)
 }
 
+describe('InventoryPage — wordmark accessibility', () => {
+  it('renders a level-1 heading with accessible name "Record Ranch"', () => {
+    mockListItems.mockReturnValue(new Promise(() => {}))
+    mockGetSummary.mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Record Ranch' }),
+    ).toBeInTheDocument()
+  })
+})
+
 describe('InventoryPage — loading state', () => {
   it('shows loading indicator while fetching', () => {
     // Never resolve so loading stays true

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/inventory'
 import { searchDiscogs, getDiscogsRelease, type DiscogsSearchResult } from '../api/discogs'
 import { EditItemPanel } from '../components/EditItemPanel'
+import { WordMark } from '../components/WordMark'
 
 interface InventoryPageProps {
   user: AuthUser
@@ -216,7 +217,9 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   return (
     <main className="app-shell">
       <header className="app-header">
-        <h1>Record Ranch</h1>
+        <h1 className="site-wordmark" aria-label="Record Ranch">
+          <WordMark />
+        </h1>
         <span className="user-id">
           {user?.signInDetails?.loginId ?? 'collector'}
         </span>


### PR DESCRIPTION
## Summary

Replace the plain `<h1>Record Ranch</h1>` text in the app header with an inline SVG wordmark component.

## Why

The text header was visually flat and generic. The new wordmark establishes visual identity with a vinyl record motif while remaining lightweight (no image assets, no external fonts) and fully accessible.

## Changes

- `ui/src/components/WordMark.tsx` — new inline SVG component: vinyl record (dark body, three groove rings, warm amber center label, spindle hole) + two-line stacked serif type (`RECORD` spaced + muted above, `RANCH` bold below)
- `ui/src/pages/InventoryPage.tsx` — import `WordMark`; replace `<h1>Record Ranch</h1>` with `<h1 className="site-wordmark" aria-label="Record Ranch"><WordMark /></h1>`
- `ui/src/App.css` — replace old `h1` size/weight rule with `.site-wordmark` (zero line-height, flex centering)

## Design decisions

- No green; the amber (#b8732a) center label is the sole warm accent — references the vintage aesthetic without novelty color
- Text uses `fill="currentColor"` — compatible with light and dark mode automatically
- Vinyl body is always near-black (#1c1c1e) — records are black regardless of color scheme
- No external font dependency — Georgia / Times New Roman serif stack used for character

## Validation

- TypeScript: no errors
- Visually reviewed in local dev server (light mode)
- `aria-label="Record Ranch"` on the wrapping `h1` preserves screen-reader semantics

## Risks / Follow-ups

- None. UI-only; no data, API, or infrastructure changes.
