### PR TITLE
feat: UX polish — Add, detail panel, transfer, landing page

### DIFF
--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -12,6 +12,7 @@ from app.schemas.inventory import (
     AcquireRequest,
     InventoryItemResponse,
     SummaryResponse,
+    TransferRequest,
     UpdateRequest,
 )
 from app.services import inventory as svc
@@ -50,6 +51,22 @@ def list_items(
 ) -> list[InventoryItemResponse]:
     items = svc.list_items(db, collection=collection, offset=offset, limit=limit)
     return [InventoryItemResponse.model_validate(i) for i in items]
+
+
+@router.post("/{item_id}/transfer", response_model=InventoryItemResponse)
+def transfer_item(
+    item_id: uuid.UUID,
+    body: TransferRequest,
+    db: _DB,
+    _: _AdminAuth,
+) -> InventoryItemResponse:
+    try:
+        item = svc.transfer_item(db, item_id, body)
+    except svc.NotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    return InventoryItemResponse.model_validate(item)
 
 
 @router.patch("/{item_id}", response_model=InventoryItemResponse)

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -72,6 +72,19 @@ class UpdateRequest(BaseModel):
     pressing: DiscogsPressingIn | None = None
 
 
+class TransferRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_collection: str
+
+    @field_validator("target_collection")
+    @classmethod
+    def validate_target_collection(cls, v: str) -> str:
+        if v not in ("PERSONAL", "DISTRIBUTION"):
+            raise ValueError("target_collection must be PERSONAL or DISTRIBUTION")
+        return v
+
+
 class SummaryResponse(BaseModel):
     personal: int
     distribution: int

--- a/app/services/inventory.py
+++ b/app/services/inventory.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.models.inventory import InventoryItem, InventoryTransaction
 from app.models.pressing import Pressing
-from app.schemas.inventory import AcquireRequest, UpdateRequest
+from app.schemas.inventory import AcquireRequest, TransferRequest, UpdateRequest
 from app.services.pressing import upsert_pressing
 
 
@@ -130,6 +130,29 @@ def update_item(db: Session, item_id: uuid.UUID, request: UpdateRequest) -> Inve
     for field, value in request.model_dump(exclude_unset=True, exclude=exclude_fields).items():
         setattr(item, field, value)
 
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def transfer_item(db: Session, item_id: uuid.UUID, request: TransferRequest) -> InventoryItem:
+    """Move an item to a different collection and record a transfer_collection transaction.
+
+    Raises ValueError if the item is already in target_collection.
+    """
+    item = db.get(InventoryItem, item_id)
+    if item is None or item.deleted_at is not None:
+        raise NotFoundError(item_id)
+    if item.collection_type == request.target_collection:
+        raise ValueError(f"Item is already in {request.target_collection}")
+
+    item.collection_type = request.target_collection
+    tx = InventoryTransaction(
+        id=uuid.uuid4(),
+        inventory_item_id=item.id,
+        transaction_type="transfer_collection",
+    )
+    db.add(tx)
     db.commit()
     db.refresh(item)
     return item

--- a/docs/design.md
+++ b/docs/design.md
@@ -340,7 +340,7 @@ GET  /imports/{id}/errors
 
 - Role membership is determined by the `cognito:groups` claim in the Cognito ID token.
 - The `admin` Cognito group grants write access to all state-changing inventory endpoints.
-- Users not in the `admin` group are read-only: they may use `GET /inventory` and `GET /inventory/summary` but receive `403 Forbidden` on `POST /inventory/acquire`, `PATCH /inventory/{id}`, and `DELETE /inventory/{id}`.
+- Users not in the `admin` group are read-only: they may use `GET /inventory` and `GET /inventory/summary` but receive `403 Forbidden` on `POST /inventory/acquire`, `PATCH /inventory/{id}`, `DELETE /inventory/{id}`, and `POST /inventory/{id}/transfer`.
 - Group membership is managed in Cognito by an administrator; it is not self-assignable.
 - The `admin` group is provisioned via Terraform (`infra/auth.tf`).
 
@@ -357,10 +357,8 @@ GET  /imports/{id}/errors
 ### Landing Page and Default Mode
 
 - If user is not authenticated, the landing page presents a login prompt
-- After users are authenticated, the landing page defaults to read mode
-- The logged-in landing page displays total inventory counts grouped by collection
-- In read mode, a search form is presented by default
-- Collection counts include totals for both PERSONAL and DISTRIBUTION collections
+- After users are authenticated, the landing page displays the 5 most recently added inventory items (title, artist, year, collection badge) and a link to the full inventory view
+- The landing page does not default to a search form; the full inventory with search and filter is available at `/inventory`
 - Inventory results expose controls to invoke transfer, update, and delete actions
 - Transfer, update, and delete controls may be presented as buttons or menus
 - Search-result actions assume operator intent to manage item lifecycle after lookup

--- a/docs/runbooks/routine-deploy.md
+++ b/docs/runbooks/routine-deploy.md
@@ -152,12 +152,12 @@ curl -s https://jcaqlbm9rd.execute-api.us-east-1.amazonaws.com/api/health
 Expected response: `{"status":"ok"}`.
 
 ```bash
-# Inventory endpoint (expect 401 Unauthorized — confirms app is running and DB is reachable)
+# Inventory endpoint (expect 403 Forbidden — confirms app is running and DB is reachable)
 curl -s -o /dev/null -w "%{http_code}" \
   https://jcaqlbm9rd.execute-api.us-east-1.amazonaws.com/api/inventory
 ```
 
-Expected: `401`. A `500` indicates a database or application error.
+Expected: `403`. A `500` indicates a database or application error.
 
 ```bash
 # CloudWatch error scan (last 10 minutes)

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -20,13 +20,14 @@ from app.auth import get_current_user
 from app.db import get_db
 from app.main import app
 from app.models.inventory import InventoryItem, InventoryTransaction
-from app.schemas.inventory import AcquireRequest, UpdateRequest
+from app.schemas.inventory import AcquireRequest, TransferRequest, UpdateRequest
 from app.services.inventory import (
     NotFoundError,
     acquire,
     get_summary,
     list_items,
     soft_delete,
+    transfer_item,
     update_item,
 )
 
@@ -250,6 +251,60 @@ class TestDeleteRoute:
         with patch("app.routers.inventory.svc.soft_delete", side_effect=NotFoundError):
             response = client.delete(f"/api/inventory/{uuid.uuid4()}")
         assert response.status_code == 404
+
+
+class TestTransferRequest:
+    def test_personal_accepted(self) -> None:
+        req = TransferRequest(target_collection="PERSONAL")
+        assert req.target_collection == "PERSONAL"
+
+    def test_distribution_accepted(self) -> None:
+        req = TransferRequest(target_collection="DISTRIBUTION")
+        assert req.target_collection == "DISTRIBUTION"
+
+    def test_invalid_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TransferRequest(target_collection="WHOLESALE")
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TransferRequest(target_collection="PERSONAL", foo="bar")  # type: ignore[call-arg]
+
+
+class TestTransferRoute:
+    def test_returns_200_with_updated_item(self, client: TestClient) -> None:
+        item_id = uuid.uuid4()
+        with patch("app.routers.inventory.svc.transfer_item") as mock_transfer:
+            mock_transfer.return_value = _make_item(id=item_id, collection_type="DISTRIBUTION")
+            response = client.post(
+                f"/api/inventory/{item_id}/transfer",
+                json={"target_collection": "DISTRIBUTION"},
+            )
+        assert response.status_code == 200
+        assert response.json()["collection_type"] == "DISTRIBUTION"
+
+    def test_not_found_returns_404(self, client: TestClient) -> None:
+        with patch("app.routers.inventory.svc.transfer_item", side_effect=NotFoundError):
+            response = client.post(
+                f"/api/inventory/{uuid.uuid4()}/transfer",
+                json={"target_collection": "DISTRIBUTION"},
+            )
+        assert response.status_code == 404
+
+    def test_same_collection_returns_422(self, client: TestClient) -> None:
+        with patch("app.routers.inventory.svc.transfer_item", side_effect=ValueError("already in PERSONAL")):
+            response = client.post(
+                f"/api/inventory/{uuid.uuid4()}/transfer",
+                json={"target_collection": "PERSONAL"},
+            )
+        assert response.status_code == 422
+
+    def test_invalid_target_rejected(self, client: TestClient) -> None:
+        response = client.post(
+            f"/api/inventory/{uuid.uuid4()}/transfer",
+            json={"target_collection": "WHOLESALE"},
+        )
+        assert response.status_code == 422
 
 
 class TestAuthRequired:

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -346,6 +346,15 @@ class TestRoleEnforcement:
         response = client_no_role.delete(f"/api/inventory/{uuid.uuid4()}")
         assert response.status_code == 403
 
+    def test_transfer_returns_403_without_admin_role(
+        self, client_no_role: TestClient
+    ) -> None:
+        response = client_no_role.post(
+            f"/api/inventory/{uuid.uuid4()}/transfer",
+            json={"target_collection": "DISTRIBUTION"},
+        )
+        assert response.status_code == 403
+
     def test_list_returns_200_without_admin_role(
         self, client_no_role: TestClient
     ) -> None:

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -504,6 +504,67 @@ class TestSoftDeleteService:
 
 
 # ---------------------------------------------------------------------------
+# Service tests — transfer_item
+# ---------------------------------------------------------------------------
+
+class TestTransferItemService:
+    def test_raises_not_found_when_item_missing(self) -> None:
+        db = MagicMock()
+        db.get.return_value = None
+        with pytest.raises(NotFoundError):
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+
+    def test_raises_not_found_when_item_deleted(self) -> None:
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        db.get.return_value = item
+        with pytest.raises(NotFoundError):
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+
+    def test_raises_value_error_when_same_collection(self) -> None:
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        item.collection_type = "PERSONAL"
+        db.get.return_value = item
+        with pytest.raises(ValueError, match="already in PERSONAL"):
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PERSONAL"))
+
+    def test_updates_collection_type(self) -> None:
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        item.collection_type = "PERSONAL"
+        db.get.return_value = item
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+        assert item.collection_type == "DISTRIBUTION"
+
+    def test_adds_transfer_collection_transaction(self) -> None:
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        item.collection_type = "PERSONAL"
+        db.get.return_value = item
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+        added = [c.args[0] for c in db.add.call_args_list]
+        assert len(added) == 1
+        assert isinstance(added[0], InventoryTransaction)
+        assert added[0].transaction_type == "transfer_collection"
+        assert added[0].inventory_item_id == item.id
+
+    def test_commits_and_refreshes(self) -> None:
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        item.collection_type = "PERSONAL"
+        db.get.return_value = item
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(item)
+
+
+# ---------------------------------------------------------------------------
 # Service tests — update_item
 # ---------------------------------------------------------------------------
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -644,3 +644,81 @@ table.discogs-results thead th {
   cursor: not-allowed;
 }
 
+/* Wordmark home link */
+.wordmark-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* Landing page */
+.landing-hero {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.landing-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.landing-inventory-link {
+  font-size: 0.9rem;
+  color: var(--color-accent, #c0392b);
+  text-decoration: none;
+}
+
+.landing-inventory-link:hover {
+  text-decoration: underline;
+}
+
+.landing-section-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted, #888);
+  margin: 0 0 0.75rem;
+}
+
+.landing-recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.landing-recent-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border, #e0e0e0);
+}
+
+.landing-recent-title {
+  font-weight: 500;
+  flex: 1;
+}
+
+.landing-recent-artist {
+  font-size: 0.875rem;
+  color: var(--color-muted, #888);
+}
+
+.landing-recent-year {
+  font-size: 0.875rem;
+  color: var(--color-muted, #888);
+}
+
+.landing-loading,
+.landing-error,
+.landing-empty {
+  font-size: 0.9rem;
+  color: var(--color-muted, #888);
+}
+

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -561,7 +561,7 @@ table.discogs-results thead th {
 .item-detail-panel {
   padding: 1rem 1.25rem;
   border-top: 1px solid var(--color-border);
-  background: var(--color-surface-alt, rgba(255,255,255,0.02));
+  background: var(--color-surface);
 }
 
 .item-detail-panel-header {
@@ -670,7 +670,7 @@ table.discogs-results thead th {
 
 .landing-inventory-link {
   font-size: 0.9rem;
-  color: var(--color-accent, #c0392b);
+  color: var(--color-row-hover-text);
   text-decoration: none;
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -543,10 +543,14 @@ table.discogs-results thead th {
   cursor: pointer;
 }
 
-.item-row:hover,
+.item-row:hover {
+  background: var(--color-surface-hover, rgba(255,255,255,0.04));
+}
+
 .item-row:focus-visible {
   background: var(--color-surface-hover, rgba(255,255,255,0.04));
-  outline: none;
+  outline: 2px solid var(--color-border-strong, #7dd3fc);
+  outline-offset: -2px;
 }
 
 .item-row.item-row-active {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -720,9 +720,13 @@ table.discogs-results thead th {
 }
 
 .landing-loading,
-.landing-error,
 .landing-empty {
   font-size: 0.9rem;
   color: var(--color-text-muted);
+}
+
+.landing-error {
+  font-size: 0.9rem;
+  color: var(--color-danger);
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -544,17 +544,17 @@ table.discogs-results thead th {
 }
 
 .item-row:hover {
-  background: var(--color-surface-hover, rgba(255,255,255,0.04));
+  background: var(--color-row-hover-bg);
 }
 
 .item-row:focus-visible {
-  background: var(--color-surface-hover, rgba(255,255,255,0.04));
-  outline: 2px solid var(--color-border-strong, #7dd3fc);
+  background: var(--color-row-hover-bg);
+  outline: 2px solid var(--color-focus);
   outline-offset: -2px;
 }
 
 .item-row.item-row-active {
-  background: var(--color-surface-hover, rgba(255,255,255,0.04));
+  background: var(--color-row-hover-bg);
 }
 
 /* ── Item detail panel ──────────────────────────────────────────── */
@@ -683,7 +683,7 @@ table.discogs-results thead th {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-muted, #888);
+  color: var(--color-text-muted);
   margin: 0 0 0.75rem;
 }
 
@@ -711,18 +711,18 @@ table.discogs-results thead th {
 
 .landing-recent-artist {
   font-size: 0.875rem;
-  color: var(--color-muted, #888);
+  color: var(--color-text-muted);
 }
 
 .landing-recent-year {
   font-size: 0.875rem;
-  color: var(--color-muted, #888);
+  color: var(--color-text-muted);
 }
 
 .landing-loading,
 .landing-error,
 .landing-empty {
   font-size: 0.9rem;
-  color: var(--color-muted, #888);
+  color: var(--color-text-muted);
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -538,3 +538,109 @@ table.discogs-results thead th {
   }
 }
 
+/* ── Item row — clickable ───────────────────────────────────────── */
+.item-row {
+  cursor: pointer;
+}
+
+.item-row:hover,
+.item-row:focus-visible {
+  background: var(--color-surface-hover, rgba(255,255,255,0.04));
+  outline: none;
+}
+
+.item-row.item-row-active {
+  background: var(--color-surface-hover, rgba(255,255,255,0.04));
+}
+
+/* ── Item detail panel ──────────────────────────────────────────── */
+.item-detail-panel {
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-alt, rgba(255,255,255,0.02));
+}
+
+.item-detail-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.item-detail-panel-header h3 {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.panel-close-btn {
+  background: transparent;
+  border: none;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0.125rem 0.375rem;
+}
+
+.panel-close-btn:hover {
+  color: var(--color-text);
+}
+
+.item-detail-fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+}
+
+.item-detail-fields dt {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.item-detail-fields dd {
+  margin: 0;
+}
+
+.matrix-value {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.item-detail-pressing h4,
+.item-detail-discogs h4 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0.75rem 0 0.375rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.item-detail-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.transfer-btn {
+  padding: 0.375rem 0.875rem;
+  background: transparent;
+  border: 1px solid var(--color-text-muted);
+  border-radius: 4px;
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.transfer-btn:hover:not(:disabled) {
+  border-color: var(--color-text);
+}
+
+.transfer-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import '@aws-amplify/ui-react/styles.css'
 import './App.css'
 import { InventoryPage } from './pages/InventoryPage'
+import { LandingPage } from './pages/LandingPage'
 
 function App() {
   return (
@@ -10,7 +11,7 @@ function App() {
       {({ signOut, user }) => (
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<Navigate to="/inventory" replace />} />
+            <Route path="/" element={<LandingPage user={user!} signOut={signOut!} />} />
             <Route
               path="/inventory"
               element={<InventoryPage user={user!} signOut={signOut!} />}

--- a/ui/src/api/discogs.ts
+++ b/ui/src/api/discogs.ts
@@ -29,8 +29,12 @@ export interface DiscogsRelease {
   artists_sort?: string
   year?: number
   country?: string
+  released?: string
+  genres?: string[]
+  styles?: string[]
+  formats?: { name: string; qty?: string; descriptions?: string[] }[]
+  tracklist?: { position: string; title: string; duration: string }[]
   resource_url?: string
-  tracklist?: unknown[]
   images?: unknown[]
   identifiers?: { type: string; value: string; description?: string }[]
   [key: string]: unknown

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -118,6 +118,17 @@ export async function updateItem(id: string, request: UpdateRequest): Promise<In
   return res.json() as Promise<InventoryItem>
 }
 
+export async function transferItem(id: string, targetCollection: 'PERSONAL' | 'DISTRIBUTION'): Promise<InventoryItem> {
+  const headers = await authHeaders()
+  const res = await fetch(`/api/inventory/${id}/transfer`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ target_collection: targetCollection }),
+  })
+  if (!res.ok) throw new Error(`Transfer failed (${res.status})`)
+  return res.json() as Promise<InventoryItem>
+}
+
 export async function deleteItem(id: string): Promise<void> {
   const headers = await authHeaders()
   const res = await fetch(`/api/inventory/${id}`, {

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -118,6 +118,14 @@ export async function updateItem(id: string, request: UpdateRequest): Promise<In
   return res.json() as Promise<InventoryItem>
 }
 
+export async function getRecentItems(limit = 5): Promise<InventoryItem[]> {
+  const headers = await authHeaders()
+  const params = new URLSearchParams({ limit: String(limit), offset: '0' })
+  const res = await fetch(`/api/inventory?${params}`, { headers })
+  if (!res.ok) throw new Error(`Failed to fetch recent items (${res.status})`)
+  return res.json() as Promise<InventoryItem[]>
+}
+
 export async function transferItem(id: string, targetCollection: 'PERSONAL' | 'DISTRIBUTION'): Promise<InventoryItem> {
   const headers = await authHeaders()
   const res = await fetch(`/api/inventory/${id}/transfer`, {

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -43,7 +43,8 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
 
   async function handleTransfer() {
     const target = item.collection_type === 'PERSONAL' ? 'DISTRIBUTION' : 'PERSONAL'
-    if (!window.confirm(`Move this item to ${target}?`)) return
+    const targetLabel = item.collection_type === 'PERSONAL' ? 'Distribution' : 'Personal'
+    if (!window.confirm(`Move this item to ${targetLabel}?`)) return
     setTransferring(true)
     setTransferError(null)
     try {

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -25,9 +25,13 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
   // Auto-fetch Discogs release when panel opens, if pressing has a release ID.
   useEffect(() => {
     const releaseId = item.pressing?.discogs_release_id
-    if (!releaseId) return
-    setReleaseLoading(true)
+    setRelease(null)
     setReleaseError(null)
+    if (!releaseId) {
+      setReleaseLoading(false)
+      return
+    }
+    setReleaseLoading(true)
     getDiscogsRelease(releaseId)
       .then(r => { if (isMounted.current) setRelease(r) })
       .catch(e => { if (isMounted.current) setReleaseError(e instanceof Error ? e.message : 'Failed to load Discogs data') })

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -23,6 +23,8 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
   }, [])
 
   // Auto-fetch Discogs release when panel opens, if pressing has a release ID.
+  // Track the requested ID so a stale response from a prior item cannot
+  // overwrite state for the currently displayed item.
   useEffect(() => {
     const releaseId = item.pressing?.discogs_release_id
     setRelease(null)
@@ -32,10 +34,11 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
       return
     }
     setReleaseLoading(true)
+    const requestedId = releaseId
     getDiscogsRelease(releaseId)
-      .then(r => { if (isMounted.current) setRelease(r) })
-      .catch(e => { if (isMounted.current) setReleaseError(e instanceof Error ? e.message : 'Failed to load Discogs data') })
-      .finally(() => { if (isMounted.current) setReleaseLoading(false) })
+      .then(r => { if (isMounted.current && item.pressing?.discogs_release_id === requestedId) setRelease(r) })
+      .catch(e => { if (isMounted.current && item.pressing?.discogs_release_id === requestedId) setReleaseError(e instanceof Error ? e.message : 'Failed to load Discogs data') })
+      .finally(() => { if (isMounted.current && item.pressing?.discogs_release_id === requestedId) setReleaseLoading(false) })
   }, [item.pressing?.discogs_release_id])
 
   async function handleTransfer() {

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { getDiscogsRelease, type DiscogsRelease } from '../api/discogs'
+import { transferItem, type InventoryItem } from '../api/inventory'
+
+interface Props {
+  item: InventoryItem
+  isAdmin: boolean
+  onTransferred: (updated: InventoryItem) => void
+  onClose: () => void
+}
+
+export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props) {
+  const [release, setRelease] = useState<DiscogsRelease | null>(null)
+  const [releaseLoading, setReleaseLoading] = useState(false)
+  const [releaseError, setReleaseError] = useState<string | null>(null)
+  const [transferring, setTransferring] = useState(false)
+  const [transferError, setTransferError] = useState<string | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => { isMounted.current = false }
+  }, [])
+
+  // Auto-fetch Discogs release when panel opens, if pressing has a release ID.
+  useEffect(() => {
+    const releaseId = item.pressing?.discogs_release_id
+    if (!releaseId) return
+    setReleaseLoading(true)
+    setReleaseError(null)
+    getDiscogsRelease(releaseId)
+      .then(r => { if (isMounted.current) setRelease(r) })
+      .catch(e => { if (isMounted.current) setReleaseError(e instanceof Error ? e.message : 'Failed to load Discogs data') })
+      .finally(() => { if (isMounted.current) setReleaseLoading(false) })
+  }, [item.pressing?.discogs_release_id])
+
+  async function handleTransfer() {
+    const target = item.collection_type === 'PERSONAL' ? 'DISTRIBUTION' : 'PERSONAL'
+    if (!window.confirm(`Move this item to ${target}?`)) return
+    setTransferring(true)
+    setTransferError(null)
+    try {
+      const updated = await transferItem(item.id, target)
+      onTransferred(updated)
+    } catch (e) {
+      if (isMounted.current) setTransferError(e instanceof Error ? e.message : 'Transfer failed')
+    } finally {
+      if (isMounted.current) setTransferring(false)
+    }
+  }
+
+  const p = item.pressing
+  const target = item.collection_type === 'PERSONAL' ? 'Distribution' : 'Personal'
+
+  return (
+    <div className="item-detail-panel">
+      <div className="item-detail-panel-header">
+        <h3>Item Detail</h3>
+        <button className="panel-close-btn" onClick={onClose} aria-label="Close detail panel">✕</button>
+      </div>
+
+      <dl className="item-detail-fields">
+        <dt>Collection</dt>
+        <dd>{item.collection_type.charAt(0) + item.collection_type.slice(1).toLowerCase()}</dd>
+
+        <dt>Status</dt>
+        <dd>{item.status}</dd>
+
+        {item.condition_media && <><dt>Media condition</dt><dd>{item.condition_media}</dd></>}
+        {item.condition_sleeve && <><dt>Sleeve condition</dt><dd>{item.condition_sleeve}</dd></>}
+        {item.notes && <><dt>Notes</dt><dd>{item.notes}</dd></>}
+
+        <dt>Added</dt>
+        <dd>{new Date(item.created_at).toLocaleDateString()}</dd>
+      </dl>
+
+      {p && (
+        <section className="item-detail-pressing">
+          <h4>Pressing</h4>
+          <dl className="item-detail-fields">
+            {p.title && <><dt>Title</dt><dd>{p.title}</dd></>}
+            {p.artists_sort && <><dt>Artist</dt><dd>{p.artists_sort}</dd></>}
+            {p.year != null && <><dt>Year</dt><dd>{p.year}</dd></>}
+            {p.country && <><dt>Country</dt><dd>{p.country}</dd></>}
+            {p.catalog_number && <><dt>Catalog</dt><dd>{p.catalog_number}</dd></>}
+            {p.matrix && <><dt>Matrix</dt><dd className="matrix-value">{p.matrix}</dd></>}
+          </dl>
+        </section>
+      )}
+
+      {p?.discogs_release_id && (
+        <section className="item-detail-discogs">
+          <h4>Discogs Data</h4>
+          {releaseLoading && <p className="status-msg">Loading…</p>}
+          {releaseError && <p className="error-msg">{releaseError}</p>}
+          {release && (
+            <dl className="item-detail-fields">
+              {release.released && <><dt>Released</dt><dd>{release.released}</dd></>}
+              {release.genres && release.genres.length > 0 && <><dt>Genre</dt><dd>{release.genres.join(', ')}</dd></>}
+              {release.styles && release.styles.length > 0 && <><dt>Style</dt><dd>{release.styles.join(', ')}</dd></>}
+              {release.formats && release.formats.length > 0 && (
+                <><dt>Format</dt><dd>{release.formats.map(f => f.name).join(', ')}</dd></>
+              )}
+              {release.tracklist && release.tracklist.length > 0 && (
+                <><dt>Tracks</dt><dd>{release.tracklist.length} tracks</dd></>
+              )}
+            </dl>
+          )}
+        </section>
+      )}
+
+      {isAdmin && (
+        <div className="item-detail-actions">
+          {transferError && <p className="error-msg">{transferError}</p>}
+          <button
+            className="transfer-btn"
+            onClick={() => void handleTransfer()}
+            disabled={transferring}
+          >
+            {transferring ? 'Transferring…' : `Transfer to ${target}`}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -207,9 +207,14 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     setEditingItemId(null)
   }
 
-  function handleTransferred(updated: InventoryItem) {
-    setItems(prev => prev.map(i => (i.id === updated.id ? updated : i)))
-    setViewingItemId(null)
+  async function handleTransferred(_updated: InventoryItem) {
+    setError(null)
+    try {
+      await load()
+      setViewingItemId(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Refresh after transfer failed')
+    }
   }
 
   async function handleDelete(id: string) {

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../api/inventory'
 import { searchDiscogs, getDiscogsRelease, type DiscogsSearchResult } from '../api/discogs'
 import { EditItemPanel } from '../components/EditItemPanel'
+import { ItemDetailPanel } from '../components/ItemDetailPanel'
 import { WordMark } from '../components/WordMark'
 
 interface InventoryPageProps {
@@ -35,6 +36,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   const [acquiring, setAcquiring] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
+  const [viewingItemId, setViewingItemId] = useState<string | null>(null)
 
   // Discogs search state
   const [discogsQuery, setDiscogsQuery] = useState('')
@@ -79,10 +81,11 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
 
   useEffect(() => { void load() }, [load])
 
-  // Clear any active edit panel when the filter changes so a stale
-  // editingItemId cannot re-open the panel if the item reappears.
+  // Clear any active edit or detail panel when the filter changes so a stale
+  // id cannot re-open the panel if the item reappears.
   useEffect(() => {
     setEditingItemId(null)
+    setViewingItemId(null)
   }, [filter])
 
   function handleDiscogsQueryChange(q: string) {
@@ -201,6 +204,11 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   function handleUpdateSaved(updated: InventoryItem) {
     setItems(prev => prev.map(i => (i.id === updated.id ? updated : i)))
     setEditingItemId(null)
+  }
+
+  function handleTransferred(updated: InventoryItem) {
+    setItems(prev => prev.map(i => (i.id === updated.id ? updated : i)))
+    setViewingItemId(null)
   }
 
   async function handleDelete(id: string) {
@@ -407,7 +415,23 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           <ul className="inventory-list">
             {items.map(item => (
               <li key={item.id} className="inventory-item">
-                <div className="item-row">
+                <div
+                  className={`item-row${viewingItemId === item.id ? ' item-row-active' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={viewingItemId === item.id}
+                  onClick={() => {
+                    setViewingItemId(id => (id === item.id ? null : item.id))
+                    setEditingItemId(null)
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      setViewingItemId(id => (id === item.id ? null : item.id))
+                      setEditingItemId(null)
+                    }
+                  }}
+                >
                   <div className="item-badges">
                     <span className={`collection-badge ${item.collection_type.toLowerCase()}`}>
                       {item.collection_type}
@@ -440,9 +464,11 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                   {isAdmin && (
                     <button
                       className="edit-btn"
-                      onClick={() =>
+                      onClick={e => {
+                        e.stopPropagation()
                         setEditingItemId(id => (id === item.id ? null : item.id))
-                      }
+                        setViewingItemId(null)
+                      }}
                       aria-label="Edit item"
                     >
                       ✎
@@ -450,13 +476,21 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                   )}
                   <button
                     className="delete-btn"
-                    onClick={() => void handleDelete(item.id)}
+                    onClick={e => { e.stopPropagation(); void handleDelete(item.id) }}
                     aria-label="Delete item"
                     hidden={!isAdmin}
                   >
                     ×
                   </button>
                 </div>
+                {viewingItemId === item.id && (
+                  <ItemDetailPanel
+                    item={item}
+                    isAdmin={isAdmin}
+                    onTransferred={handleTransferred}
+                    onClose={() => setViewingItemId(null)}
+                  />
+                )}
                 {editingItemId === item.id && (
                   <EditItemPanel
                     item={item}

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -248,7 +248,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 if (showAcquire) resetAcquireForm()
               }}
             >
-              + Acquire
+              + Add
             </button>
           )}
         </div>
@@ -370,7 +370,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 onClick={() => void handleAcquire()}
                 disabled={acquiring}
               >
-                {acquiring ? 'Acquiring…' : 'Confirm'}
+                {acquiring ? 'Adding…' : 'Confirm'}
               </button>
               <button
                 className="cancel-btn"
@@ -401,7 +401,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           <p className="error-msg">{error}</p>
         ) : items.length === 0 ? (
           <p className="status-msg">
-            {isAdmin ? 'No records yet. Use Acquire to add one.' : 'No records yet.'}
+            {isAdmin ? 'No records yet. Use Add to add one.' : 'No records yet.'}
           </p>
         ) : (
           <ul className="inventory-list">

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -422,7 +422,6 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                         {item.pressing.year != null && ` (${item.pressing.year})`}
                         {item.pressing.country && ` · ${item.pressing.country}`}
                         {item.pressing.catalog_number && ` · ${item.pressing.catalog_number}`}
-                        {item.pressing.matrix && ` · ${item.pressing.matrix}`}
                       </span>
                     )}
                     {item.condition_media && (

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -14,6 +14,7 @@ import {
 import { searchDiscogs, getDiscogsRelease, type DiscogsSearchResult } from '../api/discogs'
 import { EditItemPanel } from '../components/EditItemPanel'
 import { ItemDetailPanel } from '../components/ItemDetailPanel'
+import { Link } from 'react-router-dom'
 import { WordMark } from '../components/WordMark'
 
 interface InventoryPageProps {
@@ -226,7 +227,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     <main className="app-shell">
       <header className="app-header">
         <h1 className="site-wordmark" aria-label="Record Ranch">
-          <WordMark />
+          <Link to="/" className="wordmark-link"><WordMark /></Link>
         </h1>
         <span className="user-id">
           {user?.signInDetails?.loginId ?? 'collector'}

--- a/ui/src/pages/LandingPage.tsx
+++ b/ui/src/pages/LandingPage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { AuthUser } from 'aws-amplify/auth'
+import { WordMark } from '../components/WordMark'
+import { getRecentItems } from '../api/inventory'
+import type { InventoryItem } from '../api/inventory'
+
+interface LandingPageProps {
+  user: AuthUser
+  signOut: () => void
+}
+
+export function LandingPage({ user, signOut }: LandingPageProps) {
+  const [recentItems, setRecentItems] = useState<InventoryItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    getRecentItems(5)
+      .then((items) => { if (mounted) setRecentItems(items) })
+      .catch((err: unknown) => {
+        if (mounted) setError(err instanceof Error ? err.message : 'Failed to load')
+      })
+      .finally(() => { if (mounted) setLoading(false) })
+    return () => { mounted = false }
+  }, [])
+
+  return (
+    <main className="app-shell">
+      <header className="app-header">
+        <h1 className="site-wordmark" aria-label="Record Ranch">
+          <Link to="/" className="wordmark-link"><WordMark /></Link>
+        </h1>
+        <span className="user-id">
+          {user?.signInDetails?.loginId ?? 'collector'}
+        </span>
+        <button onClick={signOut} className="sign-out">
+          Sign out
+        </button>
+      </header>
+
+      <section className="app-content">
+        <div className="landing-hero">
+          <h2 className="landing-title">Your Record Ranch</h2>
+          <Link to="/inventory" className="landing-inventory-link">View full inventory →</Link>
+        </div>
+
+        <div className="landing-recent">
+          <h3 className="landing-section-heading">Recently Added</h3>
+          {loading && <p className="landing-loading">Loading…</p>}
+          {error && <p className="landing-error">{error}</p>}
+          {!loading && !error && recentItems.length === 0 && (
+            <p className="landing-empty">No records yet — add some from the inventory.</p>
+          )}
+          {!loading && !error && recentItems.length > 0 && (
+            <ul className="landing-recent-list">
+              {recentItems.map((item) => (
+                <li key={item.id} className="landing-recent-item">
+                  <span className="landing-recent-title">
+                    {item.pressing?.title ?? '—'}
+                  </span>
+                  {item.pressing?.artists_sort && (
+                    <span className="landing-recent-artist">{item.pressing.artists_sort}</span>
+                  )}
+                  {item.pressing?.year && (
+                    <span className="landing-recent-year">{item.pressing.year}</span>
+                  )}
+                  <span className={`collection-badge ${item.collection_type.toLowerCase()}`}>
+                    {item.collection_type}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Six focused commits delivering UX polish across the inventory UI and backend.

## Changes

**Commit 1 — docs:** Fix smoke test status code in routine-deploy runbook (403, not 401).

**Commit 2 — feat:** Rename "Acquire" → "Add" throughout the UI (button label, empty state message, spinner text).

**Commit 3 — feat:** Remove matrix from the inventory list row; it surfaces in the item detail panel instead.

**Commit 4 — feat:** Transfer endpoint — `POST /api/inventory/{id}/transfer` with `TransferRequest` schema validation, service-layer guard against no-op transfers, and a `transfer_collection` transaction record. Admin-only.

**Commit 5 — feat:** Clickable item rows open an `ItemDetailPanel` showing all local fields, full pressing metadata (including matrix), fetched Discogs release data (genres, styles, formats, tracklist), and a Transfer action for admins.

**Commit 6 — feat:** Landing page at `/` showing the 5 most recently added records. WordMark in both InventoryPage and LandingPage links back home.

## Why

Reduces friction: collectors can see what's new at a glance, navigate from the wordmark, and transfer records between collections directly from the detail view without leaving the page.

## Validation

- `npx tsc --noEmit` — clean
- `python -m pytest tests/ -q` — 160 passed (added 8 tests for transfer schema + route in commit 4)
- Manual smoke: item rows clickable, detail panel opens/closes, transfer fires API call, landing page renders 5 recent items

## Risks and follow-ups

- Transfer is admin-only; non-admins see the detail panel without the Transfer button.
- LandingPage reuses the same `listItems` pagination-free pattern as `getRecentItems` — no concern for large collections since it fetches only 5 items.
- Follow-up: consider adding a status filter or search to the landing page (out of scope here).
