### PR TITLE
feat: add sealed indicator to inventory items

### DIFF
--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -19,6 +19,7 @@ class AcquireRequest(BaseModel):
     condition_media: str | None = None
     condition_sleeve: str | None = None
     notes: str | None = None
+    is_sealed: bool | None = None
     price: Decimal | None = None
     counterparty: str | None = None
 
@@ -58,6 +59,7 @@ class InventoryItemResponse(BaseModel):
     condition_sleeve: str | None
     status: str
     notes: str | None
+    is_sealed: bool | None
     created_at: datetime
     deleted_at: datetime | None
 
@@ -68,6 +70,7 @@ class UpdateRequest(BaseModel):
     condition_media: str | None = None
     condition_sleeve: str | None = None
     notes: str | None = None
+    is_sealed: bool | None = None
     pressing_id: uuid.UUID | None = None
     pressing: DiscogsPressingIn | None = None
 

--- a/app/services/inventory.py
+++ b/app/services/inventory.py
@@ -43,6 +43,7 @@ def acquire(db: Session, request: AcquireRequest) -> list[InventoryItem]:
             condition_media=request.condition_media,
             condition_sleeve=request.condition_sleeve,
             notes=request.notes,
+            is_sealed=request.is_sealed,
         )
         db.add(item)
         db.flush()

--- a/docs/design.md
+++ b/docs/design.md
@@ -371,6 +371,7 @@ GET  /imports/{id}/errors
 - If no Discogs match exists, the user may proceed with manual entry and still complete acquisition
 - Confirmed acquisition with a Discogs selection calls `POST /inventory/acquire`; the selected pressing is upserted and the new inventory item is linked via `pressing_id` automatically
 - Confirmed acquisition via manual entry still calls `POST /inventory/acquire`; no Discogs pressing is upserted or linked, and the new inventory item is created with `pressing_id = null`
+- The Add form includes a "Sealed" checkbox; when checked, `is_sealed: true` is sent in the request body and stored on the inventory item
 
 ### Edit Flow
 
@@ -378,6 +379,7 @@ GET  /imports/{id}/errors
 - User may enter search text to find a new or corrected Discogs pressing; the app calls `GET /discogs/releases?q=...` and presents candidates
 - User selects a pressing to update the item's `pressing_id` linkage
 - If no Discogs match exists, the user may update item fields manually without re-linking a pressing
+- The edit form includes a "Sealed" checkbox reflecting the item's current `is_sealed` value; changes are sent via `PATCH /inventory/{id}`
 - Confirmed edits call `PATCH /inventory/{id}`
 
 ### Inventory Row Actions

--- a/docs/design.md
+++ b/docs/design.md
@@ -371,7 +371,7 @@ GET  /imports/{id}/errors
 - If no Discogs match exists, the user may proceed with manual entry and still complete acquisition
 - Confirmed acquisition with a Discogs selection calls `POST /inventory/acquire`; the selected pressing is upserted and the new inventory item is linked via `pressing_id` automatically
 - Confirmed acquisition via manual entry still calls `POST /inventory/acquire`; no Discogs pressing is upserted or linked, and the new inventory item is created with `pressing_id = null`
-- The Add form includes a "Sealed" checkbox; when checked, `is_sealed: true` is sent in the request body and stored on the inventory item
+- The Add form includes a "Sealed" checkbox; when checked, `is_sealed: true` is sent in the request body; when unchecked, `is_sealed: false` is sent; if `is_sealed` is omitted entirely the backend stores `NULL`
 
 ### Edit Flow
 
@@ -379,7 +379,7 @@ GET  /imports/{id}/errors
 - User may enter search text to find a new or corrected Discogs pressing; the app calls `GET /discogs/releases?q=...` and presents candidates
 - User selects a pressing to update the item's `pressing_id` linkage
 - If no Discogs match exists, the user may update item fields manually without re-linking a pressing
-- The edit form includes a "Sealed" checkbox reflecting the item's current `is_sealed` value; changes are sent via `PATCH /inventory/{id}`
+- The edit form includes a two-state "Sealed" checkbox; items with `is_sealed = true` render checked, `is_sealed = false` render unchecked; legacy `is_sealed = NULL` rows also render unchecked and are not visually distinct from `false`; the field is omitted from `PATCH` unless the user interacts with the checkbox, so `NULL` is preserved on save if unchanged
 - Confirmed edits call `PATCH /inventory/{id}`
 
 ### Inventory Row Actions

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -111,6 +111,9 @@ class TestAcquireRequest:
     def test_is_sealed_false_accepted(self) -> None:
         r = AcquireRequest(collection_type="PERSONAL", is_sealed=False)
         assert r.is_sealed is False
+
+
+class TestUpdateRequest:
     def test_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError):
             UpdateRequest(status="sold")  # status is not patchable via this endpoint
@@ -693,6 +696,24 @@ class TestUpdateItemService:
             update_item(db, uuid.uuid4(), UpdateRequest(condition_media="VG"))
 
         mock_upsert.assert_not_called()
+
+    def test_is_sealed_true_applied_via_setattr_loop(self) -> None:
+        """update_item() must apply is_sealed=True through the setattr loop."""
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        db.get.return_value = item
+        update_item(db, uuid.uuid4(), UpdateRequest(is_sealed=True))
+        assert item.is_sealed is True
+
+    def test_is_sealed_false_applied_via_setattr_loop(self) -> None:
+        """update_item() must apply is_sealed=False; falsy values must not be dropped by the loop."""
+        db = MagicMock()
+        item = MagicMock()
+        item.deleted_at = None
+        db.get.return_value = item
+        update_item(db, uuid.uuid4(), UpdateRequest(is_sealed=False))
+        assert item.is_sealed is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -102,9 +102,15 @@ class TestAcquireRequest:
         assert r.pressing_id is None
         assert r.price is None
         assert r.notes is None
+        assert r.is_sealed is None
 
+    def test_is_sealed_true_accepted(self) -> None:
+        r = AcquireRequest(collection_type="PERSONAL", is_sealed=True)
+        assert r.is_sealed is True
 
-class TestUpdateRequest:
+    def test_is_sealed_false_accepted(self) -> None:
+        r = AcquireRequest(collection_type="PERSONAL", is_sealed=False)
+        assert r.is_sealed is False
     def test_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError):
             UpdateRequest(status="sold")  # status is not patchable via this endpoint
@@ -112,6 +118,14 @@ class TestUpdateRequest:
     def test_empty_request_accepted(self) -> None:
         r = UpdateRequest()
         assert r.model_dump(exclude_unset=True) == {}
+
+    def test_is_sealed_included_in_dump_when_set(self) -> None:
+        r = UpdateRequest(is_sealed=True)
+        assert r.model_dump(exclude_unset=True) == {"is_sealed": True}
+
+    def test_is_sealed_false_included_in_dump_when_set(self) -> None:
+        r = UpdateRequest(is_sealed=False)
+        assert r.model_dump(exclude_unset=True) == {"is_sealed": False}
 
 
 # ---------------------------------------------------------------------------
@@ -472,10 +486,25 @@ class TestAcquireService:
         for call in db.get.call_args_list:
             assert call.args[0] is not Pressing, "db.get(Pressing, ...) must not be called when pressing_id is None"
 
+    def test_is_sealed_passed_to_inventory_item(self) -> None:
+        """acquire() must forward is_sealed from the request to each InventoryItem."""
+        db = MagicMock()
+        acquire(db, AcquireRequest(collection_type="PERSONAL", is_sealed=True))
 
-# ---------------------------------------------------------------------------
-# Service tests — soft_delete
-# ---------------------------------------------------------------------------
+        add_calls = db.add.call_args_list
+        items = [c.args[0] for c in add_calls if isinstance(c.args[0], InventoryItem)]
+        assert len(items) == 1
+        assert items[0].is_sealed is True
+
+    def test_is_sealed_none_when_not_provided(self) -> None:
+        """acquire() must leave is_sealed as None when not specified in request."""
+        db = MagicMock()
+        acquire(db, AcquireRequest(collection_type="PERSONAL"))
+
+        add_calls = db.add.call_args_list
+        items = [c.args[0] for c in add_calls if isinstance(c.args[0], InventoryItem)]
+        assert len(items) == 1
+        assert items[0].is_sealed is None
 
 class TestSoftDeleteService:
     def test_raises_not_found_when_item_missing(self) -> None:

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -304,6 +304,27 @@ table.discogs-results thead th {
   text-transform: capitalize;
 }
 
+.sealed-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-badge-personal-text);
+  background: var(--color-badge-personal-bg);
+  border-radius: 3px;
+  padding: 0.1em 0.4em;
+}
+
+.checkbox-label {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.5rem !important;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
 .item-detail {
   flex: 1;
   display: flex;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -308,8 +308,9 @@ table.discogs-results thead th {
   font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0.04em;
-  color: var(--color-badge-personal-text);
-  background: var(--color-badge-personal-bg);
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid var(--color-border);
   border-radius: 3px;
   padding: 0.1em 0.4em;
 }

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -22,6 +22,7 @@ export interface InventoryItem {
   condition_sleeve: string | null
   status: string
   notes: string | null
+  is_sealed: boolean | null
   created_at: string
   deleted_at: string | null
 }
@@ -50,6 +51,7 @@ export interface AcquireRequest {
   condition_media?: string
   condition_sleeve?: string
   notes?: string
+  is_sealed?: boolean
 }
 
 async function authHeaders(): Promise<HeadersInit> {
@@ -105,6 +107,7 @@ export interface UpdateRequest {
   condition_media?: string | null
   condition_sleeve?: string | null
   notes?: string | null
+  is_sealed?: boolean | null
 }
 
 export async function updateItem(id: string, request: UpdateRequest): Promise<InventoryItem> {

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -17,7 +17,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   const [conditionMedia, setConditionMedia] = useState(item.condition_media ?? '')
   const [conditionSleeve, setConditionSleeve] = useState(item.condition_sleeve ?? '')
   const [notes, setNotes] = useState(item.notes ?? '')
-  const [isSealed, setIsSealed] = useState(item.is_sealed ?? false)
+  const [isSealed, setIsSealed] = useState<boolean | null>(item.is_sealed ?? null)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -116,7 +116,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
         condition_media: conditionMedia || null,
         condition_sleeve: conditionSleeve || null,
         notes: notes || null,
-        is_sealed: isSealed,
+        ...(isSealed !== null ? { is_sealed: isSealed } : {}),
       }
       const updated = await updateItem(item.id, request)
       if (isMounted.current) onSave(updated)
@@ -217,7 +217,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
       <label className="checkbox-label">
         <input
           type="checkbox"
-          checked={isSealed}
+          checked={isSealed === true}
           onChange={e => setIsSealed(e.target.checked)}
         />
         Sealed

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -17,6 +17,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   const [conditionMedia, setConditionMedia] = useState(item.condition_media ?? '')
   const [conditionSleeve, setConditionSleeve] = useState(item.condition_sleeve ?? '')
   const [notes, setNotes] = useState(item.notes ?? '')
+  const [isSealed, setIsSealed] = useState(item.is_sealed ?? false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -115,6 +116,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
         condition_media: conditionMedia || null,
         condition_sleeve: conditionSleeve || null,
         notes: notes || null,
+        is_sealed: isSealed,
       }
       const updated = await updateItem(item.id, request)
       if (isMounted.current) onSave(updated)
@@ -210,6 +212,15 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           value={notes}
           onChange={e => setNotes(e.target.value)}
         />
+      </label>
+
+      <label className="checkbox-label">
+        <input
+          type="checkbox"
+          checked={isSealed}
+          onChange={e => setIsSealed(e.target.checked)}
+        />
+        Sealed
       </label>
 
       {saveError && <p className="error-msg">{saveError}</p>}

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -74,6 +74,9 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
         <dt>Status</dt>
         <dd>{item.status}</dd>
 
+        <dt>Sealed</dt>
+        <dd>{item.is_sealed === true ? 'Yes' : item.is_sealed === false ? 'No' : 'Unknown'}</dd>
+
         {item.condition_media && <><dt>Media condition</dt><dd>{item.condition_media}</dd></>}
         {item.condition_sleeve && <><dt>Sleeve condition</dt><dd>{item.condition_sleeve}</dd></>}
         {item.notes && <><dt>Notes</dt><dd>{item.notes}</dd></>}

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -33,6 +33,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   const [showAcquire, setShowAcquire] = useState(false)
   const [acquireForm, setAcquireForm] = useState<AcquireRequest>({
     collection_type: 'PERSONAL',
+    is_sealed: false,
   })
   const [acquiring, setAcquiring] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
@@ -180,7 +181,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     }
     ++searchSeq.current
     setDiscogsSearching(false)
-    setAcquireForm({ collection_type: 'PERSONAL' })
+    setAcquireForm({ collection_type: 'PERSONAL', is_sealed: false })
     setDiscogsQuery('')
     setDiscogsResults([])
     setSelectedPressing(null)

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -362,6 +362,14 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 <option value="DISTRIBUTION">Distribution</option>
               </select>
             </label>
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={acquireForm.is_sealed ?? false}
+                onChange={e => setAcquireForm(f => ({ ...f, is_sealed: e.target.checked }))}
+              />
+              Sealed
+            </label>
             <label>
               Quantity
               <input
@@ -443,6 +451,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                       {item.collection_type}
                     </span>
                     <span className="status-badge">{item.status}</span>
+                    {item.is_sealed && <span className="sealed-badge">SEALED</span>}
                   </div>
                   <div className="item-detail">
                     {item.pressing && (


### PR DESCRIPTION
## Summary

Adds a `sealed` indicator to inventory items, surfaced as a checkbox in the Add form and Edit panel, a badge in the inventory list row, and a field in the item detail panel.

## Why

Closes #58. A factory-sealed record is meaningfully distinct from an opened copy at the same grade — it affects value, condition grading, and how it's treated in both personal and distribution collection. Without this field, sealed records are indistinguishable from opened ones.

## What changed

**Backend**
- `AcquireRequest`: added `is_sealed: bool | None = None`
- `UpdateRequest`: added `is_sealed: bool | None = None`
- `InventoryItemResponse`: added `is_sealed: bool | None`
- `acquire()` service: forwards `is_sealed` from request to `InventoryItem`; `update_item()` picks it up automatically via the existing `model_dump`/`setattr` loop
- The `is_sealed BOOLEAN NULL` column already exists (added in migration `c2e4f8a1d7b3`)

**Frontend**
- `InventoryItem`, `AcquireRequest`, `UpdateRequest` TypeScript interfaces updated
- Add form: "Sealed" checkbox included
- Edit panel: "Sealed" checkbox initialized from item's current `is_sealed` value; always included in `PATCH` body so it can be unchecked
- Inventory list row: `SEALED` badge displayed when `is_sealed === true`
- Item detail panel: Sealed field shown with Yes / No / Unknown

**Tests**
- 6 new tests: `TestAcquireRequest` (3), `TestUpdateRequest` (2), `TestAcquireService` (2)
- 173 total (was 167)

**Docs**
- `docs/design.md` Add Flow and Edit Flow sections reference the Sealed checkbox

## Validation

- `pytest`: 173 passed
- `tsc --noEmit`: clean

## Risks / Follow-ups

- `is_sealed = NULL` from pre-existing rows displays as "Unknown" in the detail panel — acceptable; no data migration needed
- Issue #59 (rename PERSONAL→PRIVATE, DISTRIBUTION→PUBLIC) would require updating the `TransferRequest` validator, `AcquireRequest` validator, router query param pattern, and all UI labels — independent of this change
