### PR TITLE
feat: rename collection types PERSONAL/DISTRIBUTION to PRIVATE/PUBLIC

### DIFF
--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -18,7 +18,7 @@ applyTo: "db/**/*.sql, migrations/**/*.sql, **/*alembic*.py, **/*models*.py, doc
 
 ## Inventory Integrity
 
-- collection_type must stay constrained to PERSONAL or DISTRIBUTION.
+- collection_type must stay constrained to PRIVATE or PUBLIC.
 - inventory_transaction must capture all state-changing operations.
 - No schema shape that allows silent reclassification.
 

--- a/.github/instructions/fullstack.instructions.md
+++ b/.github/instructions/fullstack.instructions.md
@@ -14,8 +14,8 @@ applyTo: "**/*.py, **/*.ts, **/*.tsx, **/*.js, **/*.jsx, requirements.txt"
 
 ## Frontend
 
-- Make PERSONAL vs DISTRIBUTION distinctions clear in UI behavior and labels.
-- Require explicit sale confirmation for PERSONAL items.
+- Make PRIVATE vs PUBLIC distinctions clear in UI behavior and labels.
+- Require explicit sale confirmation for PRIVATE items.
 - Avoid exposing dangerous actions without clear user intent.
 
 ## Discogs Integration

--- a/app/models/inventory.py
+++ b/app/models/inventory.py
@@ -21,8 +21,8 @@ from app.models.pressing import Pressing  # noqa: F401 — registers Pressing on
 
 
 class CollectionType(str, enum.Enum):
-    PERSONAL = "PERSONAL"
-    DISTRIBUTION = "DISTRIBUTION"
+    PRIVATE = "PRIVATE"
+    PUBLIC = "PUBLIC"
 
 
 class ItemStatus(str, enum.Enum):
@@ -45,7 +45,7 @@ class InventoryItem(Base):
     __tablename__ = "inventory_item"
     __table_args__ = (
         CheckConstraint(
-            "collection_type IN ('PERSONAL', 'DISTRIBUTION')",
+            "collection_type IN ('PRIVATE', 'PUBLIC')",
             name="ck_inventory_item_collection_type",
         ),
         CheckConstraint(

--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -44,7 +44,7 @@ def list_items(
     db: _DB,
     _: _Auth,
     collection: Annotated[
-        str | None, Query(pattern="^(PERSONAL|DISTRIBUTION)$")
+        str | None, Query(pattern="^(PRIVATE|PUBLIC)$")
     ] = None,
     offset: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -26,8 +26,8 @@ class AcquireRequest(BaseModel):
     @field_validator("collection_type")
     @classmethod
     def validate_collection_type(cls, v: str) -> str:
-        if v not in ("PERSONAL", "DISTRIBUTION"):
-            raise ValueError("collection_type must be PERSONAL or DISTRIBUTION")
+        if v not in ("PRIVATE", "PUBLIC"):
+            raise ValueError("collection_type must be PRIVATE or PUBLIC")
         return v
 
 
@@ -83,12 +83,12 @@ class TransferRequest(BaseModel):
     @field_validator("target_collection")
     @classmethod
     def validate_target_collection(cls, v: str) -> str:
-        if v not in ("PERSONAL", "DISTRIBUTION"):
-            raise ValueError("target_collection must be PERSONAL or DISTRIBUTION")
+        if v not in ("PRIVATE", "PUBLIC"):
+            raise ValueError("target_collection must be PRIVATE or PUBLIC")
         return v
 
 
 class SummaryResponse(BaseModel):
-    personal: int
-    distribution: int
+    private: int
+    public: int
     total: int

--- a/app/services/inventory.py
+++ b/app/services/inventory.py
@@ -102,12 +102,12 @@ def get_summary(db: Session) -> dict[str, int]:
         .group_by(InventoryItem.collection_type)
     ).all()
     counts = {r[0]: r[1] for r in rows}
-    personal = counts.get("PERSONAL", 0)
-    distribution = counts.get("DISTRIBUTION", 0)
+    private = counts.get("PRIVATE", 0)
+    public = counts.get("PUBLIC", 0)
     return {
-        "personal": personal,
-        "distribution": distribution,
-        "total": personal + distribution,
+        "private": private,
+        "public": public,
+        "total": private + public,
     }
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ flowchart TD
   - `POST /inventory/bulk/transfer`
   - `POST /inventory/bulk/update`
   - `POST /inventory/bulk/delete`
-  - `GET /inventory?collection=PERSONAL|DISTRIBUTION`
+  - `GET /inventory?collection=PRIVATE|PUBLIC`
   - `GET /inventory/summary`
   - `GET /transactions`
   - `POST /imports/access/validate`
@@ -148,8 +148,8 @@ flowchart TD
 - Read mode surfaces Discogs market/value signals when available for user decision support
 - Acquire flow: user enters search text, selects a matching Discogs pressing from returned candidates, then confirms acquisition details; if the release is not in Discogs, the user may enter metadata manually
 - Edit flow: same Discogs search-and-select UX to re-link or update pressing on an existing inventory item; manual update is available as a fallback when no Discogs match is found
-- Distinguishes PERSONAL vs DISTRIBUTION visually
-- Sale confirmation for personal items
+- Distinguishes PRIVATE vs PUBLIC visually
+- Sale confirmation for private items
 - Listing optimized for quick sales workflows
 
 ### 3a. AWS Microservice Profile
@@ -214,7 +214,7 @@ Current baseline infrastructure is defined as Terraform in `infra/` and includes
 1. **Acquisition**
    - User adds record → creates `inventory_item` + `inventory_transaction`
 2. **Transfer**
-   - PERSONAL ↔ DISTRIBUTION
+   - PRIVATE ↔ PUBLIC
    - Transaction created with type `transfer_collection`
    - Item collection type updated
 3. **Sale**
@@ -241,16 +241,16 @@ flowchart TD
 
   F[User initiates transfer] --> G[POST /inventory/:id/transfer]
   G --> H{Current collection type}
-  H -->|PERSONAL| I[Set collection_type to DISTRIBUTION]
-  H -->|DISTRIBUTION| J[Set collection_type to PERSONAL]
+  H -->|PRIVATE| I[Set collection_type to PUBLIC]
+  H -->|PUBLIC| J[Set collection_type to PRIVATE]
   I --> K[Create inventory_transaction: transfer_collection]
   J --> K
   K --> L[Audit trail updated]
 
   M[User initiates sale] --> N[POST /inventory/:id/sell]
   N --> O{collection type}
-  O -->|PERSONAL| P[Require explicit confirmation]
-  O -->|DISTRIBUTION| Q[Standard sale workflow]
+  O -->|PRIVATE| P[Require explicit confirmation]
+  O -->|PUBLIC| Q[Standard sale workflow]
   P --> R[Create inventory_transaction: sale]
   Q --> R
   R --> S[Update inventory status]
@@ -280,7 +280,7 @@ flowchart TD
 
 - Discogs: release search and metadata enrichment for acquire and edit flows
 - Analytics dashboards (future)
-- Automated premium pricing for PERSONAL collection (future)
+- Automated premium pricing for PRIVATE collection (future)
 
 ### Discogs Integration (High Level)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,8 +111,8 @@ Application runtime must be configurable with infrastructure-produced values, in
 
 Each inventory item belongs to one of:
 
-- PERSONAL
-- DISTRIBUTION
+- PRIVATE
+- PUBLIC
 
 ---
 
@@ -125,7 +125,7 @@ inventory_item (
   id                   UUID PK,
   pressing_id          UUID NULL,           -- FK to pressing; populated during acquire/edit via Discogs search-and-select (Phase A); nullable to support manual entry without a Discogs match
   acquisition_batch_id UUID NULL,          -- shared across batch-acquired copies
-  collection_type      TEXT NOT NULL CHECK (collection_type IN ('PERSONAL','DISTRIBUTION')),
+  collection_type      TEXT NOT NULL CHECK (collection_type IN ('PRIVATE','PUBLIC')),
   condition_media      TEXT NULL,
   condition_sleeve     TEXT NULL,
   is_sealed            BOOLEAN NULL,        -- NULL = not recorded; TRUE = factory sealed; FALSE = confirmed open
@@ -187,7 +187,7 @@ FK constraint uses `ON DELETE RESTRICT`: transactions cannot be orphaned; invent
 
 ## Collection Rules
 
-### PERSONAL Collection
+### PRIVATE Collection
 
 - Default: not for sale
 - Sale requires explicit action
@@ -197,7 +197,7 @@ FK constraint uses `ON DELETE RESTRICT`: transactions cannot be orphaned; invent
 
 ---
 
-### DISTRIBUTION Collection
+### PUBLIC Collection
 
 - Default: available for sale
 - Standard workflows apply
@@ -257,7 +257,7 @@ Result:
 
 ## Transfer Workflow (Critical)
 
-### PERSONAL → DISTRIBUTION
+### PRIVATE → PUBLIC
 
 Use case:
 
@@ -268,11 +268,11 @@ Action:
 - Create transaction:
   - type: transfer_collection
 - Update:
-  - collection_type = DISTRIBUTION
+  - collection_type = PUBLIC
 
 ---
 
-### DISTRIBUTION → PERSONAL
+### PUBLIC → PRIVATE
 
 Use case:
 
@@ -286,14 +286,14 @@ Same transaction model
 flowchart TD
   A[Transfer requested] --> B{Direction}
 
-  B -->|PERSONAL to DISTRIBUTION| C[Use case: collector decides to sell]
+  B -->|PRIVATE to PUBLIC| C[Use case: collector decides to sell]
   C --> D[Create transaction: transfer_collection]
-  D --> E[Update collection_type to DISTRIBUTION]
-  E --> F[Item becomes sale-eligible in distribution workflows]
+  D --> E[Update collection_type to PUBLIC]
+  E --> F[Item becomes sale-eligible in public inventory workflows]
 
-  B -->|DISTRIBUTION to PERSONAL| G[Use case: collector retains item]
+  B -->|PUBLIC to PRIVATE| G[Use case: collector retains item]
   G --> H[Create transaction: transfer_collection]
-  H --> I[Update collection_type to PERSONAL]
+  H --> I[Update collection_type to PRIVATE]
   I --> J[Item exits default for-sale inventory]
 
   F --> K[No silent reclassification]
@@ -313,7 +313,7 @@ POST /inventory/{id}/transfer
 POST /inventory/bulk/transfer
 POST /inventory/bulk/update
 POST /inventory/bulk/delete
-GET  /inventory?collection=PERSONAL|DISTRIBUTION
+GET  /inventory?collection=PRIVATE|PUBLIC
 GET  /inventory/summary
 GET  /transactions
 GET  /discogs/releases?q=... (release search proxy — requires app authentication (Cognito JWT); proxies to Discogs public database search, which does not require Discogs user auth; rate-limited; returns candidate pressings for selection in acquire and edit flows)
@@ -419,13 +419,13 @@ GET  /imports/{id}/errors
 - If Discogs market data is unavailable or the on-demand fetch fails, the interface must display an explicit unavailable state.
 - Signals must not be retrieved in the background or pre-fetched for list views; fetches are user-triggered only.
 
-### Personal Collection Pricing
+### Private Collection Pricing
 
 - Visually distinct (badge/label)
 - Sale action requires confirmation
 - Possibly hidden from “for sale” views
 
-### Distribution Inventory
+### Public Inventory
 
 - Default listing view
 - Optimized for quick sales workflows
@@ -442,7 +442,7 @@ GET  /imports/{id}/errors
 ### Distribution
 
 - Market-based pricing (Discogs integration later)
-- Discogs market/value signals should be visible in distribution workflows to inform operator pricing decisions
+- Discogs market/value signals should be visible in public inventory workflows to inform operator pricing decisions
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -434,12 +434,12 @@ GET  /imports/{id}/errors
 
 ## Pricing Behavior
 
-### Personal Collection
+### Private Collection
 
 - Manual pricing
 - Optional premium multiplier (future)
 
-### Distribution
+### Public
 
 - Market-based pricing (Discogs integration later)
 - Discogs market/value signals should be visible in public inventory workflows to inform operator pricing decisions

--- a/migrations/versions/e3b7a91f2c84_rename_collection_types_private_public.py
+++ b/migrations/versions/e3b7a91f2c84_rename_collection_types_private_public.py
@@ -1,0 +1,63 @@
+"""rename collection_type values PERSONAL/DISTRIBUTION -> PRIVATE/PUBLIC
+
+Revision ID: e3b7a91f2c84
+Revises: 346f77d5b693
+Create Date: 2026-04-10
+
+Schema notes:
+- Drops the old check constraint, renames all existing values atomically,
+  then re-creates the constraint with the new allowed set.
+- UPDATE statements run inside the same transaction as the DDL (Alembic
+  default for non-transactional DB dialects; PostgreSQL supports this).
+- NULL collection_type rows cannot exist (NOT NULL constraint), so no
+  special handling is needed for absent values.
+
+Rollback intent:
+  Reverse the value rename and re-create the old constraint.
+  No data is destroyed by upgrade or downgrade.
+"""
+
+from alembic import op
+
+revision = "e3b7a91f2c84"  # pragma: allowlist secret
+down_revision = "346f77d5b693"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_inventory_item_collection_type",
+        "inventory_item",
+        type_="check",
+    )
+    op.execute(
+        "UPDATE inventory_item SET collection_type = 'PRIVATE' WHERE collection_type = 'PERSONAL'"
+    )
+    op.execute(
+        "UPDATE inventory_item SET collection_type = 'PUBLIC' WHERE collection_type = 'DISTRIBUTION'"
+    )
+    op.create_check_constraint(
+        "ck_inventory_item_collection_type",
+        "inventory_item",
+        "collection_type IN ('PRIVATE', 'PUBLIC')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_inventory_item_collection_type",
+        "inventory_item",
+        type_="check",
+    )
+    op.execute(
+        "UPDATE inventory_item SET collection_type = 'PERSONAL' WHERE collection_type = 'PRIVATE'"
+    )
+    op.execute(
+        "UPDATE inventory_item SET collection_type = 'DISTRIBUTION' WHERE collection_type = 'PUBLIC'"
+    )
+    op.create_check_constraint(
+        "ck_inventory_item_collection_type",
+        "inventory_item",
+        "collection_type IN ('PERSONAL', 'DISTRIBUTION')",
+    )

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -51,7 +51,7 @@ def _make_item(**overrides: object) -> MagicMock:
     item.pressing_id = None
     item.pressing = None
     item.acquisition_batch_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
-    item.collection_type = "PERSONAL"
+    item.collection_type = "PRIVATE"
     item.condition_media = None
     item.condition_sleeve = None
     item.status = "active"
@@ -68,14 +68,14 @@ def _make_item(**overrides: object) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 class TestAcquireRequest:
-    def test_personal_collection_accepted(self) -> None:
-        r = AcquireRequest(collection_type="PERSONAL")
-        assert r.collection_type == "PERSONAL"
+    def test_private_collection_accepted(self) -> None:
+        r = AcquireRequest(collection_type="PRIVATE")
+        assert r.collection_type == "PRIVATE"
         assert r.quantity == 1
 
-    def test_distribution_collection_accepted(self) -> None:
-        r = AcquireRequest(collection_type="DISTRIBUTION")
-        assert r.collection_type == "DISTRIBUTION"
+    def test_public_collection_accepted(self) -> None:
+        r = AcquireRequest(collection_type="PUBLIC")
+        assert r.collection_type == "PUBLIC"
 
     def test_invalid_collection_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -83,33 +83,33 @@ class TestAcquireRequest:
 
     def test_quantity_zero_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            AcquireRequest(collection_type="PERSONAL", quantity=0)
+            AcquireRequest(collection_type="PRIVATE", quantity=0)
 
     def test_quantity_101_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            AcquireRequest(collection_type="PERSONAL", quantity=101)
+            AcquireRequest(collection_type="PRIVATE", quantity=101)
 
     def test_extra_field_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            AcquireRequest(collection_type="PERSONAL", unknown_field="oops")
+            AcquireRequest(collection_type="PRIVATE", unknown_field="oops")
 
     def test_quantity_100_accepted(self) -> None:
-        r = AcquireRequest(collection_type="PERSONAL", quantity=100)
+        r = AcquireRequest(collection_type="PRIVATE", quantity=100)
         assert r.quantity == 100
 
     def test_optional_fields_default_none(self) -> None:
-        r = AcquireRequest(collection_type="PERSONAL")
+        r = AcquireRequest(collection_type="PRIVATE")
         assert r.pressing_id is None
         assert r.price is None
         assert r.notes is None
         assert r.is_sealed is None
 
     def test_is_sealed_true_accepted(self) -> None:
-        r = AcquireRequest(collection_type="PERSONAL", is_sealed=True)
+        r = AcquireRequest(collection_type="PRIVATE", is_sealed=True)
         assert r.is_sealed is True
 
     def test_is_sealed_false_accepted(self) -> None:
-        r = AcquireRequest(collection_type="PERSONAL", is_sealed=False)
+        r = AcquireRequest(collection_type="PRIVATE", is_sealed=False)
         assert r.is_sealed is False
 
 
@@ -166,7 +166,7 @@ class TestAcquireRoute:
             mock_acquire.return_value = [_make_item()]
             response = client.post(
                 "/api/inventory/acquire",
-                json={"collection_type": "PERSONAL"},
+                json={"collection_type": "PRIVATE"},
             )
         assert response.status_code == 201
         assert len(response.json()) == 1
@@ -176,7 +176,7 @@ class TestAcquireRoute:
             mock_acquire.return_value = [_make_item() for _ in range(5)]
             response = client.post(
                 "/api/inventory/acquire",
-                json={"collection_type": "DISTRIBUTION", "quantity": 5},
+                json={"collection_type": "PUBLIC", "quantity": 5},
             )
         assert response.status_code == 201
         assert len(response.json()) == 5
@@ -184,7 +184,7 @@ class TestAcquireRoute:
     def test_quantity_101_rejected_before_service(self, client: TestClient) -> None:
         response = client.post(
             "/api/inventory/acquire",
-            json={"collection_type": "PERSONAL", "quantity": 101},
+            json={"collection_type": "PRIVATE", "quantity": 101},
         )
         assert response.status_code == 422
 
@@ -207,10 +207,10 @@ class TestListRoute:
     def test_collection_filter_passed_to_service(self, client: TestClient) -> None:
         with patch("app.routers.inventory.svc.list_items") as mock_list:
             mock_list.return_value = []
-            response = client.get("/api/inventory?collection=PERSONAL")
+            response = client.get("/api/inventory?collection=PRIVATE")
         assert response.status_code == 200
         mock_list.assert_called_once()
-        assert mock_list.call_args.kwargs["collection"] == "PERSONAL"
+        assert mock_list.call_args.kwargs["collection"] == "PRIVATE"
 
     def test_invalid_collection_param_rejected(self, client: TestClient) -> None:
         response = client.get("/api/inventory?collection=BADVALUE")
@@ -220,12 +220,12 @@ class TestListRoute:
 class TestSummaryRoute:
     def test_returns_200_with_counts(self, client: TestClient) -> None:
         with patch("app.routers.inventory.svc.get_summary") as mock_summary:
-            mock_summary.return_value = {"personal": 3, "distribution": 2, "total": 5}
+            mock_summary.return_value = {"private": 3, "public": 2, "total": 5}
             response = client.get("/api/inventory/summary")
         assert response.status_code == 200
         body = response.json()
-        assert body["personal"] == 3
-        assert body["distribution"] == 2
+        assert body["private"] == 3
+        assert body["public"] == 2
         assert body["total"] == 5
 
 
@@ -271,13 +271,13 @@ class TestDeleteRoute:
 
 
 class TestTransferRequest:
-    def test_personal_accepted(self) -> None:
-        req = TransferRequest(target_collection="PERSONAL")
-        assert req.target_collection == "PERSONAL"
+    def test_private_accepted(self) -> None:
+        req = TransferRequest(target_collection="PRIVATE")
+        assert req.target_collection == "PRIVATE"
 
-    def test_distribution_accepted(self) -> None:
-        req = TransferRequest(target_collection="DISTRIBUTION")
-        assert req.target_collection == "DISTRIBUTION"
+    def test_public_accepted(self) -> None:
+        req = TransferRequest(target_collection="PUBLIC")
+        assert req.target_collection == "PUBLIC"
 
     def test_invalid_value_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -285,34 +285,34 @@ class TestTransferRequest:
 
     def test_extra_field_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            TransferRequest(target_collection="PERSONAL", foo="bar")  # type: ignore[call-arg]
+            TransferRequest(target_collection="PRIVATE", foo="bar")  # type: ignore[call-arg]
 
 
 class TestTransferRoute:
     def test_returns_200_with_updated_item(self, client: TestClient) -> None:
         item_id = uuid.uuid4()
         with patch("app.routers.inventory.svc.transfer_item") as mock_transfer:
-            mock_transfer.return_value = _make_item(id=item_id, collection_type="DISTRIBUTION")
+            mock_transfer.return_value = _make_item(id=item_id, collection_type="PUBLIC")
             response = client.post(
                 f"/api/inventory/{item_id}/transfer",
-                json={"target_collection": "DISTRIBUTION"},
+                json={"target_collection": "PUBLIC"},
             )
         assert response.status_code == 200
-        assert response.json()["collection_type"] == "DISTRIBUTION"
+        assert response.json()["collection_type"] == "PUBLIC"
 
     def test_not_found_returns_404(self, client: TestClient) -> None:
         with patch("app.routers.inventory.svc.transfer_item", side_effect=NotFoundError):
             response = client.post(
                 f"/api/inventory/{uuid.uuid4()}/transfer",
-                json={"target_collection": "DISTRIBUTION"},
+                json={"target_collection": "PUBLIC"},
             )
         assert response.status_code == 404
 
     def test_same_collection_returns_422(self, client: TestClient) -> None:
-        with patch("app.routers.inventory.svc.transfer_item", side_effect=ValueError("already in PERSONAL")):
+        with patch("app.routers.inventory.svc.transfer_item", side_effect=ValueError("already in PRIVATE")):
             response = client.post(
                 f"/api/inventory/{uuid.uuid4()}/transfer",
-                json={"target_collection": "PERSONAL"},
+                json={"target_collection": "PRIVATE"},
             )
         assert response.status_code == 422
 
@@ -344,7 +344,7 @@ class TestRoleEnforcement:
     ) -> None:
         response = client_no_role.post(
             "/api/inventory/acquire",
-            json={"collection_type": "PERSONAL"},
+            json={"collection_type": "PRIVATE"},
         )
         assert response.status_code == 403
 
@@ -368,7 +368,7 @@ class TestRoleEnforcement:
     ) -> None:
         response = client_no_role.post(
             f"/api/inventory/{uuid.uuid4()}/transfer",
-            json={"target_collection": "DISTRIBUTION"},
+            json={"target_collection": "PUBLIC"},
         )
         assert response.status_code == 403
 
@@ -384,7 +384,7 @@ class TestRoleEnforcement:
         self, client_no_role: TestClient
     ) -> None:
         with patch("app.routers.inventory.svc.get_summary") as mock_summary:
-            mock_summary.return_value = {"personal": 0, "distribution": 0, "total": 0}
+            mock_summary.return_value = {"private": 0, "public": 0, "total": 0}
             response = client_no_role.get("/api/inventory/summary")
         assert response.status_code == 200
 
@@ -396,32 +396,32 @@ class TestRoleEnforcement:
 class TestAcquireService:
     def test_single_item_creates_one_item_and_one_transaction(self) -> None:
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="PERSONAL"))
+        acquire(db, AcquireRequest(collection_type="PRIVATE"))
         assert db.add.call_count == 2  # 1 item + 1 transaction
         assert db.flush.call_count == 1
         assert db.commit.call_count == 1
 
     def test_quantity_three_creates_six_db_adds(self) -> None:
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="DISTRIBUTION", quantity=3))
+        acquire(db, AcquireRequest(collection_type="PUBLIC", quantity=3))
         assert db.add.call_count == 6  # 3 items + 3 transactions
         assert db.flush.call_count == 3
         assert db.commit.call_count == 1
 
     def test_all_items_share_acquisition_batch_id(self) -> None:
         db = MagicMock()
-        items = acquire(db, AcquireRequest(collection_type="PERSONAL", quantity=3))
+        items = acquire(db, AcquireRequest(collection_type="PRIVATE", quantity=3))
         batch_ids = {item.acquisition_batch_id for item in items}
         assert len(batch_ids) == 1
 
     def test_returns_list_of_correct_length(self) -> None:
         db = MagicMock()
-        result = acquire(db, AcquireRequest(collection_type="PERSONAL", quantity=4))
+        result = acquire(db, AcquireRequest(collection_type="PRIVATE", quantity=4))
         assert len(result) == 4
 
     def test_transaction_references_item_id_and_type(self) -> None:
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="PERSONAL"))
+        acquire(db, AcquireRequest(collection_type="PRIVATE"))
         added = [c.args[0] for c in db.add.call_args_list]
         item_obj, tx_obj = added[0], added[1]
         assert isinstance(item_obj, InventoryItem)
@@ -431,7 +431,7 @@ class TestAcquireService:
 
     def test_item_ids_are_set_explicitly(self) -> None:
         db = MagicMock()
-        items = acquire(db, AcquireRequest(collection_type="PERSONAL", quantity=2))
+        items = acquire(db, AcquireRequest(collection_type="PRIVATE", quantity=2))
         assert all(isinstance(i.id, uuid.UUID) for i in items)
         assert items[0].id != items[1].id
 
@@ -451,7 +451,7 @@ class TestAcquireService:
             country="UK",
         )
         with patch("app.services.inventory.upsert_pressing", return_value=pressing_uuid) as mock_upsert:
-            items = acquire(db, AcquireRequest(collection_type="PERSONAL", pressing=pressing_in))
+            items = acquire(db, AcquireRequest(collection_type="PRIVATE", pressing=pressing_in))
 
         mock_upsert.assert_called_once_with(db, pressing_in)
         assert items[0].pressing_id == pressing_uuid
@@ -459,7 +459,7 @@ class TestAcquireService:
     def test_pressing_upsert_not_called_without_pressing(self) -> None:
         db = MagicMock()
         with patch("app.services.inventory.upsert_pressing") as mock_upsert:
-            acquire(db, AcquireRequest(collection_type="PERSONAL"))
+            acquire(db, AcquireRequest(collection_type="PRIVATE"))
         mock_upsert.assert_not_called()
 
     def test_pressing_object_eagerly_assigned_to_avoid_n_plus_one(self) -> None:
@@ -475,7 +475,7 @@ class TestAcquireService:
 
         pressing_in = DiscogsPressingIn(discogs_release_id=1)
         with patch("app.services.inventory.upsert_pressing", return_value=pressing_uuid):
-            acquire(db, AcquireRequest(collection_type="PERSONAL", quantity=3, pressing=pressing_in))
+            acquire(db, AcquireRequest(collection_type="PRIVATE", quantity=3, pressing=pressing_in))
 
         db.get.assert_called_once_with(Pressing, pressing_uuid)
 
@@ -484,7 +484,7 @@ class TestAcquireService:
         from app.models.pressing import Pressing
 
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="PERSONAL"))
+        acquire(db, AcquireRequest(collection_type="PRIVATE"))
 
         for call in db.get.call_args_list:
             assert call.args[0] is not Pressing, "db.get(Pressing, ...) must not be called when pressing_id is None"
@@ -492,7 +492,7 @@ class TestAcquireService:
     def test_is_sealed_passed_to_inventory_item(self) -> None:
         """acquire() must forward is_sealed from the request to each InventoryItem."""
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="PERSONAL", is_sealed=True))
+        acquire(db, AcquireRequest(collection_type="PRIVATE", is_sealed=True))
 
         add_calls = db.add.call_args_list
         items = [c.args[0] for c in add_calls if isinstance(c.args[0], InventoryItem)]
@@ -502,7 +502,7 @@ class TestAcquireService:
     def test_is_sealed_none_when_not_provided(self) -> None:
         """acquire() must leave is_sealed as None when not specified in request."""
         db = MagicMock()
-        acquire(db, AcquireRequest(collection_type="PERSONAL"))
+        acquire(db, AcquireRequest(collection_type="PRIVATE"))
 
         add_calls = db.add.call_args_list
         items = [c.args[0] for c in add_calls if isinstance(c.args[0], InventoryItem)]
@@ -544,7 +544,7 @@ class TestTransferItemService:
         db = MagicMock()
         db.get.return_value = None
         with pytest.raises(NotFoundError):
-            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PUBLIC"))
 
     def test_raises_not_found_when_item_deleted(self) -> None:
         db = MagicMock()
@@ -552,33 +552,33 @@ class TestTransferItemService:
         item.deleted_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
         db.get.return_value = item
         with pytest.raises(NotFoundError):
-            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PUBLIC"))
 
     def test_raises_value_error_when_same_collection(self) -> None:
         db = MagicMock()
         item = MagicMock()
         item.deleted_at = None
-        item.collection_type = "PERSONAL"
+        item.collection_type = "PRIVATE"
         db.get.return_value = item
-        with pytest.raises(ValueError, match="already in PERSONAL"):
-            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PERSONAL"))
+        with pytest.raises(ValueError, match="already in PRIVATE"):
+            transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PRIVATE"))
 
     def test_updates_collection_type(self) -> None:
         db = MagicMock()
         item = MagicMock()
         item.deleted_at = None
-        item.collection_type = "PERSONAL"
+        item.collection_type = "PRIVATE"
         db.get.return_value = item
-        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
-        assert item.collection_type == "DISTRIBUTION"
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PUBLIC"))
+        assert item.collection_type == "PUBLIC"
 
     def test_adds_transfer_collection_transaction(self) -> None:
         db = MagicMock()
         item = MagicMock()
         item.deleted_at = None
-        item.collection_type = "PERSONAL"
+        item.collection_type = "PRIVATE"
         db.get.return_value = item
-        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PUBLIC"))
         added = [c.args[0] for c in db.add.call_args_list]
         assert len(added) == 1
         assert isinstance(added[0], InventoryTransaction)
@@ -589,9 +589,9 @@ class TestTransferItemService:
         db = MagicMock()
         item = MagicMock()
         item.deleted_at = None
-        item.collection_type = "PERSONAL"
+        item.collection_type = "PRIVATE"
         db.get.return_value = item
-        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="DISTRIBUTION"))
+        transfer_item(db, uuid.uuid4(), TransferRequest(target_collection="PUBLIC"))
         db.commit.assert_called_once()
         db.refresh.assert_called_once_with(item)
 
@@ -724,24 +724,24 @@ class TestGetSummaryService:
     def test_returns_correct_counts(self) -> None:
         db = MagicMock()
         db.execute.return_value.all.return_value = [
-            ("PERSONAL", 4),
-            ("DISTRIBUTION", 7),
+            ("PRIVATE", 4),
+            ("PUBLIC", 7),
         ]
         result = get_summary(db)
-        assert result == {"personal": 4, "distribution": 7, "total": 11}
+        assert result == {"private": 4, "public": 7, "total": 11}
 
     def test_returns_zeros_when_empty(self) -> None:
         db = MagicMock()
         db.execute.return_value.all.return_value = []
         result = get_summary(db)
-        assert result == {"personal": 0, "distribution": 0, "total": 0}
+        assert result == {"private": 0, "public": 0, "total": 0}
 
     def test_handles_single_collection(self) -> None:
         db = MagicMock()
-        db.execute.return_value.all.return_value = [("PERSONAL", 3)]
+        db.execute.return_value.all.return_value = [("PRIVATE", 3)]
         result = get_summary(db)
-        assert result["personal"] == 3
-        assert result["distribution"] == 0
+        assert result["private"] == 3
+        assert result["public"] == 0
         assert result["total"] == 3
 
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -288,12 +288,12 @@ table.discogs-results thead th {
   width: fit-content;
 }
 
-.collection-badge.personal {
+.collection-badge.private {
   background: var(--color-badge-personal-bg);
   color: var(--color-badge-personal-text);
 }
 
-.collection-badge.distribution {
+.collection-badge.public {
   background: var(--color-badge-distribution-bg);
   color: var(--color-badge-distribution-text);
 }

--- a/ui/src/api/inventory.test.ts
+++ b/ui/src/api/inventory.test.ts
@@ -37,9 +37,9 @@ describe('listItems', () => {
 
   it('appends collection param when provided', async () => {
     mockFetch.mockReturnValue(jsonResponse([]))
-    await listItems('PERSONAL')
+    await listItems('PRIVATE')
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toContain('collection=PERSONAL')
+    expect(url).toContain('collection=PRIVATE')
   })
 
   it('throws on non-ok response', async () => {
@@ -85,7 +85,7 @@ describe('listItems', () => {
 
 describe('getSummary', () => {
   it('returns summary data', async () => {
-    const data = { personal: 2, distribution: 3, total: 5 }
+    const data = { private: 2, public: 3, total: 5 }
     mockFetch.mockReturnValue(jsonResponse(data))
     const result = await getSummary()
     expect(result).toEqual(data)
@@ -102,16 +102,16 @@ describe('getSummary', () => {
 describe('acquireItems', () => {
   it('POSTs with correct body', async () => {
     mockFetch.mockReturnValue(jsonResponse([]))
-    await acquireItems({ collection_type: 'PERSONAL', quantity: 2 })
+    await acquireItems({ collection_type: 'PRIVATE', quantity: 2 })
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/inventory/acquire')
     expect(opts.method).toBe('POST')
-    expect(JSON.parse(opts.body as string)).toEqual({ collection_type: 'PERSONAL', quantity: 2 })
+    expect(JSON.parse(opts.body as string)).toEqual({ collection_type: 'PRIVATE', quantity: 2 })
   })
 
   it('throws on non-ok response', async () => {
     mockFetch.mockReturnValue(jsonResponse({}, 422))
-    await expect(acquireItems({ collection_type: 'DISTRIBUTION' })).rejects.toThrow('Acquire failed (422)')
+    await expect(acquireItems({ collection_type: 'PUBLIC' })).rejects.toThrow('Acquire failed (422)')
   })
 })
 
@@ -136,7 +136,7 @@ describe('updateItem', () => {
     pressing_id: null,
     pressing: null,
     acquisition_batch_id: null,
-    collection_type: 'PERSONAL',
+    collection_type: 'PRIVATE',
     condition_media: 'NM',
     condition_sleeve: null,
     status: 'AVAILABLE',

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -17,7 +17,7 @@ export interface InventoryItem {
   pressing_id: string | null
   pressing: PressingBookmark | null
   acquisition_batch_id: string | null
-  collection_type: 'PERSONAL' | 'DISTRIBUTION'
+  collection_type: 'PRIVATE' | 'PUBLIC'
   condition_media: string | null
   condition_sleeve: string | null
   status: string
@@ -28,8 +28,8 @@ export interface InventoryItem {
 }
 
 export interface SummaryResponse {
-  personal: number
-  distribution: number
+  private: number
+  public: number
   total: number
 }
 
@@ -45,7 +45,7 @@ export interface DiscogsPressingIn {
 }
 
 export interface AcquireRequest {
-  collection_type: 'PERSONAL' | 'DISTRIBUTION'
+  collection_type: 'PRIVATE' | 'PUBLIC'
   quantity?: number
   pressing?: DiscogsPressingIn
   condition_media?: string
@@ -129,7 +129,7 @@ export async function getRecentItems(limit = 5): Promise<InventoryItem[]> {
   return res.json() as Promise<InventoryItem[]>
 }
 
-export async function transferItem(id: string, targetCollection: 'PERSONAL' | 'DISTRIBUTION'): Promise<InventoryItem> {
+export async function transferItem(id: string, targetCollection: 'PRIVATE' | 'PUBLIC'): Promise<InventoryItem> {
   const headers = await authHeaders()
   const res = await fetch(`/api/inventory/${id}/transfer`, {
     method: 'POST',

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -42,8 +42,8 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
   }, [item.pressing?.discogs_release_id])
 
   async function handleTransfer() {
-    const target = item.collection_type === 'PERSONAL' ? 'DISTRIBUTION' : 'PERSONAL'
-    const targetLabel = item.collection_type === 'PERSONAL' ? 'Distribution' : 'Personal'
+    const target = item.collection_type === 'PRIVATE' ? 'PUBLIC' : 'PRIVATE'
+    const targetLabel = item.collection_type === 'PRIVATE' ? 'Public' : 'Private'
     if (!window.confirm(`Move this item to ${targetLabel}?`)) return
     setTransferring(true)
     setTransferError(null)
@@ -58,7 +58,7 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
   }
 
   const p = item.pressing
-  const target = item.collection_type === 'PERSONAL' ? 'Distribution' : 'Personal'
+  const target = item.collection_type === 'PRIVATE' ? 'Public' : 'Private'
 
   return (
     <div className="item-detail-panel">

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -48,15 +48,15 @@ const mockUser = {
 }
 const mockSignOut = vi.fn()
 
-const emptySummary = { personal: 0, distribution: 0, total: 0 }
-const filledSummary = { personal: 1, distribution: 2, total: 3 }
+const emptySummary = { private: 0, public: 0, total: 0 }
+const filledSummary = { private: 1, public: 2, total: 3 }
 
 const sampleItem = {
   id: 'item-1',
   pressing_id: null,
   pressing: null,
   acquisition_batch_id: null,
-  collection_type: 'PERSONAL' as const,
+  collection_type: 'PRIVATE' as const,
   condition_media: 'VG+',
   condition_sleeve: null,
   status: 'AVAILABLE',
@@ -118,8 +118,8 @@ describe('InventoryPage — empty state', () => {
     mockGetSummary.mockResolvedValue(filledSummary)
     renderPage()
     await waitFor(() => expect(screen.getByText('3')).toBeInTheDocument()) // total
-    expect(screen.getByText('1')).toBeInTheDocument() // personal
-    expect(screen.getByText('2')).toBeInTheDocument() // distribution
+    expect(screen.getByText('1')).toBeInTheDocument() // private
+    expect(screen.getByText('2')).toBeInTheDocument() // public
   })
 })
 
@@ -146,7 +146,7 @@ describe('InventoryPage — item list', () => {
     mockListItems.mockResolvedValue([sampleItem])
     mockGetSummary.mockResolvedValue(filledSummary)
     renderPage()
-    await waitFor(() => expect(screen.getByText('PERSONAL')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('PRIVATE')).toBeInTheDocument())
     expect(screen.getByText('AVAILABLE')).toBeInTheDocument()
     expect(screen.getByText('Media: VG+')).toBeInTheDocument()
   })
@@ -179,19 +179,19 @@ describe('InventoryPage — acquire flow', () => {
 })
 
 describe('InventoryPage — filter buttons', () => {
-  it('renders All, Personal, Distribution filter buttons', async () => {
+  it('renders All, Private, Public filter buttons', async () => {
     renderPage()
     await waitFor(() => expect(screen.getByText('All')).toBeInTheDocument())
-    expect(screen.getByText('Personal')).toBeInTheDocument()
-    expect(screen.getByText('Distribution')).toBeInTheDocument()
+    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.getByText('Public')).toBeInTheDocument()
   })
 
   it('calls listItems with filter param on filter change', async () => {
     renderPage()
     await waitFor(() => expect(mockListItems).toHaveBeenCalledWith(undefined))
     const user = userEvent.setup()
-    await user.click(screen.getByText('Personal'))
-    await waitFor(() => expect(mockListItems).toHaveBeenCalledWith('PERSONAL'))
+    await user.click(screen.getByText('Private'))
+    await waitFor(() => expect(mockListItems).toHaveBeenCalledWith('PRIVATE'))
   })
 })
 
@@ -456,8 +456,8 @@ describe('InventoryPage — edit flow', () => {
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: 'Edit item' }))
     expect(screen.getByPlaceholderText('Search Discogs to change pressing…')).toBeInTheDocument()
-    // Switch to Distribution filter — panel should close
-    await user.click(screen.getByText('Distribution'))
+    // Switch to Public filter — panel should close
+    await user.click(screen.getByText('Public'))
     expect(screen.queryByPlaceholderText('Search Discogs to change pressing…')).not.toBeInTheDocument()
   })
 })

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -22,7 +22,7 @@ interface InventoryPageProps {
   signOut: () => void
 }
 
-type CollectionFilter = 'ALL' | 'PERSONAL' | 'DISTRIBUTION'
+type CollectionFilter = 'ALL' | 'PRIVATE' | 'PUBLIC'
 
 export function InventoryPage({ user, signOut }: InventoryPageProps) {
   const [items, setItems] = useState<InventoryItem[]>([])
@@ -32,7 +32,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   const [error, setError] = useState<string | null>(null)
   const [showAcquire, setShowAcquire] = useState(false)
   const [acquireForm, setAcquireForm] = useState<AcquireRequest>({
-    collection_type: 'PERSONAL',
+    collection_type: 'PRIVATE',
     is_sealed: false,
   })
   const [acquiring, setAcquiring] = useState(false)
@@ -181,7 +181,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     }
     ++searchSeq.current
     setDiscogsSearching(false)
-    setAcquireForm({ collection_type: 'PERSONAL', is_sealed: false })
+    setAcquireForm({ collection_type: 'PRIVATE', is_sealed: false })
     setDiscogsQuery('')
     setDiscogsResults([])
     setSelectedPressing(null)
@@ -249,8 +249,8 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
             <h2>Inventory</h2>
             {summary && (
               <div className="summary-counts">
-                <span>Personal: <strong>{summary.personal}</strong></span>
-                <span>Distribution: <strong>{summary.distribution}</strong></span>
+                <span>Private: <strong>{summary.private}</strong></span>
+                <span>Public: <strong>{summary.public}</strong></span>
                 <span className="summary-total">Total: <strong>{summary.total}</strong></span>
               </div>
             )}
@@ -355,12 +355,12 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 onChange={e =>
                   setAcquireForm(f => ({
                     ...f,
-                    collection_type: e.target.value as 'PERSONAL' | 'DISTRIBUTION',
+                    collection_type: e.target.value as 'PRIVATE' | 'PUBLIC',
                   }))
                 }
               >
-                <option value="PERSONAL">Personal</option>
-                <option value="DISTRIBUTION">Distribution</option>
+                <option value="PRIVATE">Private</option>
+                <option value="PUBLIC">Public</option>
               </select>
             </label>
             <label className="checkbox-label">
@@ -407,7 +407,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
         )}
 
         <div className="filter-group">
-          {(['ALL', 'PERSONAL', 'DISTRIBUTION'] as CollectionFilter[]).map(f => (
+          {(['ALL', 'PRIVATE', 'PUBLIC'] as CollectionFilter[]).map(f => (
             <button
               key={f}
               className={`filter-btn${filter === f ? ' active' : ''}`}


### PR DESCRIPTION
## Summary

Renames the two collection types throughout the system:

- `PERSONAL` → `PRIVATE`
- `DISTRIBUTION` → `PUBLIC`

## Why

Closes #59. "Personal" and "Distribution" are internal operational terms. "Private" and "Public" are more intuitive and map naturally to how the distinction would be understood by a visitor or future user — records kept privately vs. records available to the public.

## What changed

**Database**

- Migration `e3b7a91f2c84`: drops `ck_inventory_item_collection_type`, renames all existing rows atomically (`PERSONAL→PRIVATE`, `DISTRIBUTION→PUBLIC`), then re-creates the constraint with `IN ('PRIVATE', 'PUBLIC')`. Downgrade reverses the rename and restores the old constraint.

**Backend**

- `CollectionType` enum: `PERSONAL/DISTRIBUTION` → `PRIVATE/PUBLIC`
- `AcquireRequest` and `TransferRequest` validators updated to `PRIVATE/PUBLIC`
- `SummaryResponse` fields: `personal/distribution` → `private/public`
- Router `collection` query param pattern: `^(PRIVATE|PUBLIC)$`
- `get_summary()` service dict keys updated

**Frontend**

- `InventoryItem`, `AcquireRequest`, `SummaryResponse`, `transferItem` TypeScript types updated
- Filter buttons: "Personal" → "Private", "Distribution" → "Public"
- Add form defaults and select options updated
- Transfer target logic and labels updated
- CSS badge classes: `.collection-badge.personal/.distribution` → `.collection-badge.private/.public`
- Summary counts display: "Private: N", "Public: N"

**Tests**

- All backend test fixtures, assertions, and parametrize values updated (175 passing)
- Frontend test fixtures and labels updated; tsc clean, build clean

**Docs**

- `docs/design.md` and `docs/architecture.md`: all references updated including SQL schema snippet, mermaid diagrams, section headings, and prose
- `.github/instructions/database.instructions.md`: constraint invariant updated
- `.github/instructions/fullstack.instructions.md`: label reference updated

## Validation

- `pytest`: 175 passed
- `tsc --noEmit`: clean
- `npm run build`: clean

## Risks / Follow-ups

- **Breaking change**: any external caller currently passing `PERSONAL` or `DISTRIBUTION` to `/inventory/acquire`, `/inventory/{id}/transfer`, or `GET /inventory?collection=` will receive a 422 after the migration is applied. There are no known external callers.
- Migration must be applied before the updated Lambda code is deployed; the `acquire()` service and router will reject the old values once deployed.
- Downgrade path is provided and reverses the rename atomically.
