### PR TITLE
fix: use alembic current to derive revision in migration handler

### DIFF
--- a/docs/runbooks/db-migrations.md
+++ b/docs/runbooks/db-migrations.md
@@ -198,11 +198,21 @@ def handler(event, context):
         [sys.executable, "-m", "alembic", "upgrade", "head"],
         capture_output=True, text=True, env=env
     )
+    # Alembic writes upgrade progress to stderr, not stdout. Derive current
+    # revision by running `alembic current` after the upgrade — its output
+    # goes to stdout and is safe to split.
+    current_revision = None
+    if result.returncode == 0:
+        current = subprocess.run(
+            [sys.executable, "-m", "alembic", "current"],
+            capture_output=True, text=True, env=env
+        )
+        current_revision = current.stdout.strip().split()[0] if current.stdout.strip() else None
     return {
         "status": "ok" if result.returncode == 0 else "error",
         "stdout": result.stdout,
         "stderr": result.stderr,
-        "current_revision": result.stdout.strip().split()[-1] if result.returncode == 0 else None,
+        "current_revision": current_revision,
     }
 ```
 


### PR DESCRIPTION
## Summary

Fixes `IndexError: list index out of range` in the `migrate_handler.py` snippet in `docs/runbooks/db-migrations.md`.

## Why

Closes #63. `alembic upgrade` writes its progress to **stderr**, leaving stdout empty. The previous handler called `result.stdout.strip().split()[-1]` which always raised `IndexError` on a successful run, causing the Lambda to return `FunctionError: Unhandled` even when the migration applied correctly.

## What changed

- After a successful `alembic upgrade head`, run a second `alembic current` subprocess to retrieve the revision — `current` writes its output to stdout and is safe to parse.
- Added an explanatory comment clarifying the stderr/stdout distinction.
- The `status`, `stdout`, and `stderr` keys in the return value are unchanged — only `current_revision` derivation is fixed.

## Validation

- markdownlint: passed
- detect-secrets: passed
- This is a pure docs/runbook change (no executable code in the repo is modified). The fix was validated operationally during the PR #62 deploy where the corrected two-step approach (upgrade → current) was used manually.
