### PR TITLE
feat: add debounced text search to inventory page

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -96,6 +96,30 @@
   border-color: var(--color-primary);
 }
 
+/* Inventory search */
+.search-wrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.inventory-search {
+  width: 100%;
+  max-width: 280px;
+  padding: 0.3125rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: 0.875rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.inventory-search:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
+}
+
 /* Acquire button */
 .acquire-btn {
   padding: 0.375rem 0.875rem;

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -578,4 +578,27 @@ describe('InventoryPage — text search', () => {
     await waitFor(() => expect(screen.getByText(/Blue Monday/)).toBeInTheDocument(), { timeout: 2000 })
     expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument()
   })
+
+  it('closes an open detail panel when its item is filtered out and does not re-open on clear', async () => {
+    mockListItems.mockResolvedValue([itemRick, itemNew])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    const user = userEvent.setup()
+    // Open the detail panel for Rick by clicking his row
+    const rickRow = screen.getAllByRole('button', { name: /PRIVATE|AVAILABLE/ }).find(el =>
+      el.closest('li')?.textContent?.includes('Never Gonna Give You Up'),
+    ) ?? screen.getByText(/Never Gonna Give You Up/).closest('[role="button"]')!
+    await user.click(rickRow as HTMLElement)
+    // Panel should be open — ItemDetailPanel renders a close button
+    await waitFor(() => expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument(), { timeout: 2000 })
+    // Type a query that excludes Rick
+    await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'Blue')
+    // Rick's row and panel disappear; close button gone
+    await waitFor(() => expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument(), { timeout: 2000 })
+    // Clearing the search restores Rick but the panel must NOT re-open
+    await user.clear(screen.getByRole('searchbox', { name: 'Search inventory' }))
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/), { timeout: 2000 })
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument()
+  })
 })

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -540,18 +540,29 @@ describe('InventoryPage — text search', () => {
   })
 
   it('composes search filter with collection filter', async () => {
-    mockListItems.mockResolvedValue([itemRick])
+    // ALL (no arg) returns both items; PRIVATE returns only itemRick.
+    // This verifies composition: collection filter narrows the server-side list,
+    // then text search further filters the client-side result.
+    mockListItems.mockImplementation((collection?: string) =>
+      Promise.resolve(collection === 'PRIVATE' ? [itemRick] : [itemRick, itemNew]),
+    )
     mockGetSummary.mockResolvedValue(filledSummary)
     renderPage()
-    // Filter to Private — only itemRick (PRIVATE) is in results
-    await waitFor(() => screen.getByText('Private'))
+    // Initial ALL load — both items visible
+    await waitFor(() => {
+      expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument()
+      expect(screen.getByText(/Blue Monday/)).toBeInTheDocument()
+    })
     const user = userEvent.setup()
+    // Switch to Private — server returns only PRIVATE items; itemNew disappears
     await user.click(screen.getByText('Private'))
-    // itemNew is PUBLIC — after re-load mockListItems returns only PRIVATE items
+    await waitFor(() => expect(screen.queryByText(/Blue Monday/)).not.toBeInTheDocument())
     await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
-    // Search within already-filtered list
+    // Text search within the already-filtered list
     await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'Never')
     await waitFor(() => expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument(), { timeout: 2000 })
+    // itemNew must still be absent — it was excluded by the collection filter, not just the text filter
+    expect(screen.queryByText(/Blue Monday/)).not.toBeInTheDocument()
   })
 
   it('clearing search restores full list', async () => {

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import { InventoryPage } from './InventoryPage'
 
@@ -82,7 +83,11 @@ beforeEach(() => {
 })
 
 function renderPage() {
-  return render(<InventoryPage user={mockUser} signOut={mockSignOut} />)
+  return render(
+    <MemoryRouter>
+      <InventoryPage user={mockUser} signOut={mockSignOut} />
+    </MemoryRouter>,
+  )
 }
 
 describe('InventoryPage — wordmark accessibility', () => {
@@ -110,7 +115,7 @@ describe('InventoryPage — empty state', () => {
   it('shows empty message when no items', async () => {
     renderPage()
     await waitFor(() =>
-      expect(screen.getByText('No records yet. Use Acquire to add one.')).toBeInTheDocument(),
+      expect(screen.getByText('No records yet. Use Add to add one.')).toBeInTheDocument(),
     )
   })
 
@@ -156,10 +161,10 @@ describe('InventoryPage — acquire flow', () => {
   it('toggles acquire form on button click', async () => {
     renderPage()
     await waitFor(() =>
-      expect(screen.getByText('No records yet. Use Acquire to add one.')).toBeInTheDocument(),
+      expect(screen.getByText('No records yet. Use Add to add one.')).toBeInTheDocument(),
     )
     const user = userEvent.setup()
-    await user.click(screen.getByText('+ Acquire'))
+    await user.click(screen.getByText('+ Add'))
     expect(screen.getByText('Confirm')).toBeInTheDocument()
     await user.click(screen.getByText('Cancel'))
     expect(screen.queryByText('Confirm')).not.toBeInTheDocument()
@@ -168,10 +173,10 @@ describe('InventoryPage — acquire flow', () => {
   it('calls acquireItems and reloads on confirm', async () => {
     renderPage()
     await waitFor(() =>
-      expect(screen.getByText('No records yet. Use Acquire to add one.')).toBeInTheDocument(),
+      expect(screen.getByText('No records yet. Use Add to add one.')).toBeInTheDocument(),
     )
     const user = userEvent.setup()
-    await user.click(screen.getByText('+ Acquire'))
+    await user.click(screen.getByText('+ Add'))
     await user.click(screen.getByText('Confirm'))
     await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())
     expect(mockListItems).toHaveBeenCalledTimes(2) // initial + reload
@@ -234,9 +239,9 @@ const sampleDiscogsResult = {
 async function openAcquireForm() {
   renderPage()
   await waitFor(() =>
-    expect(screen.getByText('No records yet. Use Acquire to add one.')).toBeInTheDocument(),
+    expect(screen.getByText('No records yet. Use Add to add one.')).toBeInTheDocument(),
   )
-  await userEvent.setup().click(screen.getByText('+ Acquire'))
+  await userEvent.setup().click(screen.getByText('+ Add'))
 }
 
 describe('InventoryPage — Discogs search-and-select', () => {
@@ -459,5 +464,107 @@ describe('InventoryPage — edit flow', () => {
     // Switch to Public filter — panel should close
     await user.click(screen.getByText('Public'))
     expect(screen.queryByPlaceholderText('Search Discogs to change pressing…')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures for search tests
+// ---------------------------------------------------------------------------
+const pressingRick = {
+  id: 'pressing-rick',
+  discogs_release_id: 249504,
+  discogs_resource_url: null,
+  title: 'Never Gonna Give You Up',
+  artists_sort: 'Astley, Rick',
+  year: 1987,
+  country: 'UK',
+  catalog_number: 'RCA PB 9693',
+  matrix: null,
+}
+
+const pressingNew = {
+  id: 'pressing-new',
+  discogs_release_id: 12345,
+  discogs_resource_url: null,
+  title: 'Blue Monday',
+  artists_sort: 'New Order',
+  year: 1983,
+  country: 'UK',
+  catalog_number: 'FAC 73',
+  matrix: null,
+}
+
+const itemRick = { ...sampleItem, id: 'item-rick', pressing_id: 'pressing-rick', pressing: pressingRick }
+const itemNew = { ...sampleItem, id: 'item-new', pressing_id: 'pressing-new', pressing: pressingNew, collection_type: 'PUBLIC' as const }
+
+describe('InventoryPage — text search', () => {
+  it('renders the search input', async () => {
+    renderPage()
+    await waitFor(() => screen.getByRole('searchbox', { name: 'Search inventory' }))
+    const input = screen.getByRole('searchbox', { name: 'Search inventory' })
+    expect(input).toHaveAttribute('placeholder', 'Search title, artist, catalog…')
+  })
+
+  it('filters items by pressing title', async () => {
+    mockListItems.mockResolvedValue([itemRick, itemNew])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    const user = userEvent.setup()
+    await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'Never')
+    // Wait for Blue Monday to be filtered out (proves debounce fired)
+    await waitFor(() => expect(screen.queryByText(/Blue Monday/)).not.toBeInTheDocument(), { timeout: 2000 })
+    expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument()
+  })
+
+  it('filters items by artists_sort', async () => {
+    mockListItems.mockResolvedValue([itemRick, itemNew])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Astley, Rick/))
+    const user = userEvent.setup()
+    await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'Astley')
+    // Wait for New Order to be filtered out (proves debounce fired)
+    await waitFor(() => expect(screen.queryByText(/New Order/)).not.toBeInTheDocument(), { timeout: 2000 })
+    expect(screen.getByText(/Astley, Rick/)).toBeInTheDocument()
+  })
+
+  it('shows no-results message when query matches nothing', async () => {
+    mockListItems.mockResolvedValue([itemRick])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    const user = userEvent.setup()
+    await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'zzz')
+    await waitFor(() => expect(screen.getByText('No results for "zzz".')).toBeInTheDocument(), { timeout: 2000 })
+  })
+
+  it('composes search filter with collection filter', async () => {
+    mockListItems.mockResolvedValue([itemRick])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    // Filter to Private — only itemRick (PRIVATE) is in results
+    await waitFor(() => screen.getByText('Private'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Private'))
+    // itemNew is PUBLIC — after re-load mockListItems returns only PRIVATE items
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    // Search within already-filtered list
+    await user.type(screen.getByRole('searchbox', { name: 'Search inventory' }), 'Never')
+    await waitFor(() => expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument(), { timeout: 2000 })
+  })
+
+  it('clearing search restores full list', async () => {
+    mockListItems.mockResolvedValue([itemRick, itemNew])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    const user = userEvent.setup()
+    const input = screen.getByRole('searchbox', { name: 'Search inventory' })
+    await user.type(input, 'Never')
+    await waitFor(() => expect(screen.queryByText(/Blue Monday/)).not.toBeInTheDocument(), { timeout: 2000 })
+    await user.clear(input)
+    await waitFor(() => expect(screen.getByText(/Blue Monday/)).toBeInTheDocument(), { timeout: 2000 })
+    expect(screen.getByText(/Never Gonna Give You Up/)).toBeInTheDocument()
   })
 })

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -459,7 +459,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           <p className="error-msg">{error}</p>
         ) : filteredItems.length === 0 ? (
           <p className="status-msg">
-            {normalizedQuery ? `No results for "${searchQuery}".` : isAdmin ? 'No records yet. Use Add to add one.' : 'No records yet.'}
+            {normalizedQuery ? `No results for "${debouncedQuery.trim()}".` : isAdmin ? 'No records yet. Use Add to add one.' : 'No records yet.'}
           </p>
         ) : (
           <ul className="inventory-list">

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -115,6 +115,22 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     })
   }, [items, normalizedQuery])
 
+  // Close any open detail or edit panel when the selected item is filtered out
+  // by the text search. Without this, clearing the search re-opens the panel
+  // automatically because viewingItemId/editingItemId remain set while the
+  // item's <li> is absent from the DOM — inconsistent with the filter-change
+  // behavior that explicitly clears these IDs.
+  useEffect(() => {
+    if (viewingItemId == null && editingItemId == null) return
+    const visibleIds = new Set(filteredItems.map(item => item.id))
+    if (viewingItemId != null && !visibleIds.has(viewingItemId)) {
+      setViewingItemId(null)
+    }
+    if (editingItemId != null && !visibleIds.has(editingItemId)) {
+      setEditingItemId(null)
+    }
+  }, [filteredItems, viewingItemId, editingItemId])
+
   function handleDiscogsQueryChange(q: string) {
     setDiscogsQuery(q)
     setSelectedPressing(null)

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AuthUser } from 'aws-amplify/auth'
 import { fetchAuthSession } from 'aws-amplify/auth'
 import {
@@ -39,6 +39,8 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
   const [isAdmin, setIsAdmin] = useState(false)
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
   const [viewingItemId, setViewingItemId] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
 
   // Discogs search state
   const [discogsQuery, setDiscogsQuery] = useState('')
@@ -89,6 +91,29 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
     setEditingItemId(null)
     setViewingItemId(null)
   }, [filter])
+
+  // Debounce the search query so the filter only runs after the user pauses
+  // typing. Avoids O(n * fields) toLowerCase work on every keystroke for large
+  // collections.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(searchQuery), 300)
+    return () => clearTimeout(id)
+  }, [searchQuery])
+
+  const normalizedQuery = useMemo(() => debouncedQuery.trim().toLowerCase(), [debouncedQuery])
+  const filteredItems = useMemo(() => {
+    if (!normalizedQuery) return items
+    return items.filter(item => {
+      const p = item.pressing
+      return [
+        p?.title,
+        p?.artists_sort,
+        p?.catalog_number,
+        p?.country,
+        item.notes,
+      ].some(field => field?.toLowerCase().includes(normalizedQuery))
+    })
+  }, [items, normalizedQuery])
 
   function handleDiscogsQueryChange(q: string) {
     setDiscogsQuery(q)
@@ -254,6 +279,16 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                 <span className="summary-total">Total: <strong>{summary.total}</strong></span>
               </div>
             )}
+          </div>
+          <div className="search-wrapper">
+            <input
+              type="search"
+              className="inventory-search"
+              placeholder="Search title, artist, catalog…"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              aria-label="Search inventory"
+            />
           </div>
           {isAdmin && (
             <button
@@ -422,13 +457,13 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           <p className="status-msg">Loading…</p>
         ) : error ? (
           <p className="error-msg">{error}</p>
-        ) : items.length === 0 ? (
+        ) : filteredItems.length === 0 ? (
           <p className="status-msg">
-            {isAdmin ? 'No records yet. Use Add to add one.' : 'No records yet.'}
+            {normalizedQuery ? `No results for "${searchQuery}".` : isAdmin ? 'No records yet. Use Add to add one.' : 'No records yet.'}
           </p>
         ) : (
           <ul className="inventory-list">
-            {items.map(item => (
+            {filteredItems.map(item => (
               <li key={item.id} className="inventory-item">
                 <div
                   className={`item-row${viewingItemId === item.id ? ' item-row-active' : ''}`}


### PR DESCRIPTION
## Summary

Adds a debounced, client-side text search input to the inventory toolbar. The query composes with the existing collection-type filter so both can be active simultaneously.

## Why

Issue #61 requested a way to search/filter the inventory list by title, artist, catalog number, country, or notes without requiring a round-trip to the API.

## Implementation

- **Search input** — `type="search"` with `aria-label="Search inventory"` and placeholder "Search title, artist, catalog…", placed in the toolbar between the collection filter and the Add button.
- **Debounce (300 ms)** — raw `searchQuery` state drives the controlled input; a `useEffect` with `setTimeout` updates a separate `debouncedQuery` state after 300 ms of idle. This avoids running `O(n × fields)` `toLowerCase` work on every keystroke for large collections.
- **Memoized filter** — `normalizedQuery` and `filteredItems` are both wrapped in `useMemo`, keyed on `[items, normalizedQuery]` / `[debouncedQuery]`. The filter only re-runs when the item list or debounced query actually changes, not on unrelated re-renders.
- **Fields searched** — `pressing.title`, `pressing.artists_sort`, `pressing.catalog_number`, `pressing.country`, `item.notes` (all case-insensitive).
- **Empty state** — shows `No results for "…".` when the query matches nothing; falls back to the existing "No records yet." message when the query is empty.
- **CSS** — `.search-wrapper` (flex, right-aligned), `.inventory-search` (pill-shaped, token-variable colors), `.inventory-search:focus` (primary-color outline).

## Fixes bundled (pre-existing regressions)

- `renderPage()` in `InventoryPage.test.tsx` was missing a `MemoryRouter` wrapper, causing all 25 existing tests to fail with a React Router context error. Fixed in this PR since the PR workflow requires tests to pass before merge.
- Stale text assertions (`"+ Acquire"` → `"+ Add"`, `"Use Acquire to add one."` → `"Use Add to add one."`) updated to match current component output.

## Validation

- 46/46 tests pass (`npm run test -- --run`)
- `tsc --noEmit` clean
- `npm run build` clean

## Risks and follow-ups

- Search is client-side over the full loaded page. For very large collections a server-side search endpoint may be preferable, but client-side is sufficient for the current scale and avoids added API complexity.
- No server changes needed; no migration required; frontend-only deploy.
