### PR TITLE
docs: add group management section to user-management runbook

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -24,12 +24,14 @@ Operational profile assumptions:
 **Decision:** `pressing` stores a lean eight-column bookmark (id, created_at, discogs_release_id, discogs_resource_url, title, artists_sort, year, country). All Discogs detail data — tracks, images, credits, labels, identifiers, market signals, community signals, raw payload — is fetched on demand via a proxy endpoint and is never stored locally.
 
 **Rationale:**
+
 - Storage costs money. Discogs data is large and changes frequently; local copies would be expensive and stale.
 - Discogs is an authoritative, reliable read-only source; duplicating it locally provides no data safety benefit.
 - At human interaction pace, the 60 req/min authenticated rate limit is not a practical constraint.
 - On-demand model eliminates background sync jobs, stale-data detection, and sync-status bookkeeping entirely.
 
 **Consequences:**
+
 - Phase B child tables (pressing_track, pressing_identifier, pressing_image, pressing_video, pressing_credit, pressing_company, pressing_label) are cancelled.
 - Phase C background sync is cancelled.
 - The Discogs API is called only on explicit user action (search, release detail, image load). No background API calls are made.

--- a/docs/runbooks/user-management.md
+++ b/docs/runbooks/user-management.md
@@ -38,6 +38,39 @@ unset TEMP_PASSWORD
 
 ---
 
+## Add a User to a Group
+
+Record Ranch uses Cognito groups for role-based access. The `admin` group grants full inventory management access (add, edit, delete). Users without this group get read-only access.
+
+```bash
+aws cognito-idp admin-add-user-to-group \
+  --user-pool-id "$COGNITO_USER_POOL_ID" \
+  --username "<email>" \
+  --group-name admin
+```
+
+Verify the assignment:
+
+```bash
+aws cognito-idp admin-list-groups-for-user \
+  --user-pool-id "$COGNITO_USER_POOL_ID" \
+  --username "<email>" \
+  --query 'Groups[*].GroupName'
+```
+
+Remove from a group:
+
+```bash
+aws cognito-idp admin-remove-user-from-group \
+  --user-pool-id "$COGNITO_USER_POOL_ID" \
+  --username "<email>" \
+  --group-name admin
+```
+
+> The `admin` group name is hardcoded in the frontend (`cognito:groups` claim check in `InventoryPage.tsx`). Do not rename the group without a corresponding frontend change.
+
+---
+
 ## List Users
 
 ```bash

--- a/docs/runbooks/user-management.md
+++ b/docs/runbooks/user-management.md
@@ -67,7 +67,7 @@ aws cognito-idp admin-remove-user-from-group \
   --group-name admin
 ```
 
-> The `admin` group name is hardcoded in the frontend (`cognito:groups` claim check in `InventoryPage.tsx`). Do not rename the group without a corresponding frontend change.
+> The `admin` group name is coupled across infrastructure and application code: it is provisioned in `infra/auth.tf`, enforced by backend authorization in `app/routers/inventory.py` (`require_role("admin")`), and checked in the frontend via the `cognito:groups` claim in `ui/src/pages/InventoryPage.tsx`. Do not rename the group unless you update all of these together.
 
 ---
 


### PR DESCRIPTION
## Summary

Add a "Add a User to a Group" section to the user-management runbook covering `admin-add-user-to-group`, `admin-list-groups-for-user`, and `admin-remove-user-from-group`.

## Why

The runbook documented creating users but had no guidance on assigning them to the `admin` group. Without this, a newly created user gets read-only access and there is no documented path to grant admin access via CLI.

## Changes

- New section between "Add a User" and "List Users" covering:
  - Add to group
  - Verify assignment
  - Remove from group
- Note that the `admin` group name is hardcoded in `InventoryPage.tsx` and must not be renamed without a corresponding frontend change.

## Validation

- `markdownlint` passed
- `detect-secrets` passed
- Pure docs change — no executable behavior, no unit test required per PR workflow

## Risks and follow-ups

None. Docs-only change.
