### PR TITLE
feat: inventory UX polish — color-coded tiles, remove badge clutter, add label to detail

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -328,15 +328,13 @@ table.discogs-results thead th {
   text-transform: capitalize;
 }
 
-.sealed-badge {
-  font-size: 0.6875rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  color: var(--color-text-muted);
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: 3px;
-  padding: 0.1em 0.4em;
+/* Collection-type color accent on tile left edge */
+.inventory-item.item-private {
+  border-left: 3px solid var(--color-badge-personal-text);
+}
+
+.inventory-item.item-public {
+  border-left: 3px solid var(--color-badge-distribution-text);
 }
 
 .checkbox-label {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -104,7 +104,7 @@
 
 .filter-btn.private.active {
   background: var(--color-badge-personal-text);
-  color: #fff;
+  color: var(--color-bg);
   border-color: var(--color-badge-personal-text);
 }
 
@@ -116,7 +116,7 @@
 
 .filter-btn.public.active {
   background: var(--color-badge-distribution-text);
-  color: #fff;
+  color: var(--color-bg);
   border-color: var(--color-badge-distribution-text);
 }
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -96,6 +96,30 @@
   border-color: var(--color-primary);
 }
 
+.filter-btn.private {
+  background: var(--color-badge-personal-bg);
+  color: var(--color-badge-personal-text);
+  border-color: var(--color-badge-personal-text);
+}
+
+.filter-btn.private.active {
+  background: var(--color-badge-personal-text);
+  color: #fff;
+  border-color: var(--color-badge-personal-text);
+}
+
+.filter-btn.public {
+  background: var(--color-badge-distribution-bg);
+  color: var(--color-badge-distribution-text);
+  border-color: var(--color-badge-distribution-text);
+}
+
+.filter-btn.public.active {
+  background: var(--color-badge-distribution-text);
+  color: #fff;
+  border-color: var(--color-badge-distribution-text);
+}
+
 /* Inventory search */
 .search-wrapper {
   flex: 1;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -361,6 +361,19 @@ table.discogs-results thead th {
   border-left: 3px solid var(--color-badge-distribution-text);
 }
 
+/* Screen-reader-only utility — visually hidden, available to AT */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .checkbox-label {
   display: flex !important;
   flex-direction: row !important;

--- a/ui/src/api/discogs.ts
+++ b/ui/src/api/discogs.ts
@@ -34,6 +34,7 @@ export interface DiscogsRelease {
   styles?: string[]
   formats?: { name: string; qty?: string; descriptions?: string[] }[]
   tracklist?: { position: string; title: string; duration: string }[]
+  labels?: { name: string; catno?: string; resource_url?: string }[]
   resource_url?: string
   images?: unknown[]
   identifiers?: { type: string; value: string; description?: string }[]

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -112,6 +112,9 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
               {release.formats && release.formats.length > 0 && (
                 <><dt>Format</dt><dd>{release.formats.map(f => f.name).join(', ')}</dd></>
               )}
+              {release.labels && release.labels.length > 0 && (
+                <><dt>Label</dt><dd>{release.labels.map(l => l.name).join(', ')}</dd></>
+              )}
               {release.tracklist && release.tracklist.length > 0 && (
                 <><dt>Tracks</dt><dd>{release.tracklist.length} tracks</dd></>
               )}

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -147,11 +147,15 @@ describe('InventoryPage — error state', () => {
 })
 
 describe('InventoryPage — item list', () => {
-  it('renders items with collection and status badges', async () => {
+  it('renders items with collection color class and status badge', async () => {
     mockListItems.mockResolvedValue([sampleItem])
     mockGetSummary.mockResolvedValue(filledSummary)
     renderPage()
-    await waitFor(() => expect(screen.getByText('PRIVATE')).toBeInTheDocument())
+    // Collection type is communicated via CSS class on the tile, not a text label.
+    await waitFor(() => {
+      const tile = document.querySelector('.inventory-item.item-private')
+      expect(tile).toBeInTheDocument()
+    })
     expect(screen.getByText('AVAILABLE')).toBeInTheDocument()
     expect(screen.getByText('Media: VG+')).toBeInTheDocument()
   })

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -606,3 +606,35 @@ describe('InventoryPage — text search', () => {
     expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument()
   })
 })
+
+describe('InventoryPage — item detail panel Discogs data', () => {
+  it('renders record label from Discogs release payload', async () => {
+    const itemWithPressing = {
+      ...sampleItem,
+      id: 'item-label-test',
+      pressing_id: 'pressing-rick',
+      pressing: {
+        ...pressingRick,
+        id: 'pressing-rick',
+        discogs_resource_url: null,
+        matrix: null,
+      },
+    }
+    mockListItems.mockResolvedValue([itemWithPressing])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    mockGetDiscogsRelease.mockResolvedValue({
+      id: 249504,
+      title: 'Never Gonna Give You Up',
+      identifiers: [],
+      labels: [{ name: 'RCA' }],
+    })
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    const user = userEvent.setup()
+    // Open detail panel by clicking the item row
+    await user.click(screen.getByText(/Never Gonna Give You Up/).closest('[role="button"]')!)
+    // Wait for the Discogs data section and assert label is rendered
+    await waitFor(() => expect(screen.getByText('RCA')).toBeInTheDocument())
+    expect(screen.getByText('Label')).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -480,7 +480,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
         ) : (
           <ul className="inventory-list">
             {filteredItems.map(item => (
-              <li key={item.id} className="inventory-item">
+              <li key={item.id} className={`inventory-item item-${item.collection_type.toLowerCase()}`}>
                 <div
                   className={`item-row${viewingItemId === item.id ? ' item-row-active' : ''}`}
                   role="button"
@@ -499,9 +499,6 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                   }}
                 >
                   <div className="item-badges">
-                    <span className={`collection-badge ${item.collection_type.toLowerCase()}`}>
-                      {item.collection_type}
-                    </span>
                     <span className="status-badge">{item.status}</span>
                   </div>
                   <div className="item-detail">

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -461,7 +461,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           {(['ALL', 'PRIVATE', 'PUBLIC'] as CollectionFilter[]).map(f => (
             <button
               key={f}
-              className={`filter-btn${filter === f ? ' active' : ''}`}
+              className={`filter-btn${f !== 'ALL' ? ` ${f.toLowerCase()}` : ''}${filter === f ? ' active' : ''}`}
               onClick={() => setFilter(f)}
             >
               {f === 'ALL' ? 'All' : f.charAt(0) + f.slice(1).toLowerCase()}

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -503,7 +503,6 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                       {item.collection_type}
                     </span>
                     <span className="status-badge">{item.status}</span>
-                    {item.is_sealed && <span className="sealed-badge">SEALED</span>}
                   </div>
                   <div className="item-detail">
                     {item.pressing && (

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -499,6 +499,9 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                   }}
                 >
                   <div className="item-badges">
+                    <span className="sr-only">
+                      {item.collection_type.charAt(0) + item.collection_type.slice(1).toLowerCase()} collection
+                    </span>
                     <span className="status-badge">{item.status}</span>
                   </div>
                   <div className="item-detail">


### PR DESCRIPTION
## Summary

Three UX polish changes to the inventory list and item detail panel, each as a separate commit to preserve decision history.

## Changes

**1. Remove SEALED badge from inventory list rows** (`07bc797`)

The sealed badge added visual clutter to every list row. Sealed status is already surfaced in the item detail panel (Yes / No / Unknown) where it has context alongside condition grades. No information is lost.

**2. Replace collection-type text badge with left-border color accent** (`a2fd45d`)

The PUBLIC / PRIVATE label occupied significant space in the badge column. Replaced with a 3px colored left border on the tile: blue for PRIVATE, green for PUBLIC. Same visual signal, zero label noise. Removes the now-dead `.sealed-badge` CSS rule in the same pass.

**3. Add record label to item detail panel** (`8dbc64d`)

Surfaces label name(s) from the Discogs on-demand release payload in the Discogs Data section. No backend change required — labels is already returned by the `/discogs/releases/{id}` proxy. The `DiscogsRelease` TypeScript interface is updated to include the `labels` field.

Note: label in the *list row* would require a schema migration to store it in the `pressing` bookmark. That is out of scope here.

## Why

Reduces label/badge clutter on inventory tiles. Collection type is communicated through color, which is faster to scan than reading text. Adds a clearly useful metadata field (record label) to the detail view.

## Validation

- 47 unit tests passing (including test updated to assert on CSS class rather than deleted badge text)
- No backend changes

## Risks and follow-ups

- Label in the list row requires a `pressing` schema migration (tracked separately)
- Color-only differentiation between collection types may need a non-color fallback for accessibility (e.g. tooltip or aria-label on the tile) — follow-up consideration
