### PR TITLE
feat: full-tile collection color + label field on pressing bookmark

### DIFF
--- a/app/models/pressing.py
+++ b/app/models/pressing.py
@@ -56,6 +56,7 @@ class Pressing(Base):
     country: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
     catalog_number: Mapped[str | None] = mapped_column(Text, nullable=True)
     matrix: Mapped[str | None] = mapped_column(Text, nullable=True)
+    label: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     items: Mapped[list["InventoryItem"]] = relationship(back_populates="pressing")

--- a/app/models/pressing.py
+++ b/app/models/pressing.py
@@ -45,7 +45,7 @@ class Pressing(Base):
     # Discogs identity and linkage — lean bookmark only.
     # Heavyweight detail (tracks, images, credits, market signals) is fetched
     # on demand and not stored. Lightweight pressing-level detail that aids
-    # identification (catalog_number, matrix) is persisted locally.
+    # identification (catalog_number, matrix, label) is persisted locally.
     discogs_release_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     discogs_resource_url: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/app/schemas/discogs.py
+++ b/app/schemas/discogs.py
@@ -22,3 +22,4 @@ class DiscogsPressingIn(BaseModel):
     country: str | None = None
     catalog_number: str | None = None
     matrix: str | None = None
+    label: str | None = None

--- a/app/schemas/inventory.py
+++ b/app/schemas/inventory.py
@@ -45,6 +45,7 @@ class PressingResponse(BaseModel):
     country: str | None
     catalog_number: str | None
     matrix: str | None
+    label: str | None
 
 
 class InventoryItemResponse(BaseModel):

--- a/app/services/pressing.py
+++ b/app/services/pressing.py
@@ -35,13 +35,13 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
         ON CONFLICT (discogs_release_id)
         WHERE discogs_release_id IS NOT NULL
         DO UPDATE SET
-            discogs_resource_url = EXCLUDED.discogs_resource_url,
-            title                = EXCLUDED.title,
-            artists_sort         = EXCLUDED.artists_sort,
-            year                 = EXCLUDED.year,
-            country              = EXCLUDED.country,
-            catalog_number       = COALESCE(EXCLUDED.catalog_number, pressing.catalog_number),
-            matrix               = COALESCE(EXCLUDED.matrix, pressing.matrix),
+            discogs_resource_url = COALESCE(pressing.discogs_resource_url, EXCLUDED.discogs_resource_url),
+            title                = COALESCE(pressing.title, EXCLUDED.title),
+            artists_sort         = COALESCE(pressing.artists_sort, EXCLUDED.artists_sort),
+            year                 = COALESCE(pressing.year, EXCLUDED.year),
+            country              = COALESCE(pressing.country, EXCLUDED.country),
+            catalog_number       = COALESCE(pressing.catalog_number, EXCLUDED.catalog_number),
+            matrix               = COALESCE(pressing.matrix, EXCLUDED.matrix),
             label                = COALESCE(pressing.label, EXCLUDED.label)
         RETURNING id
         """

--- a/app/services/pressing.py
+++ b/app/services/pressing.py
@@ -28,10 +28,10 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
         """
         INSERT INTO pressing
             (discogs_release_id, discogs_resource_url, title, artists_sort, year, country,
-             catalog_number, matrix)
+             catalog_number, matrix, label)
         VALUES
             (:discogs_release_id, :discogs_resource_url, :title, :artists_sort, :year, :country,
-             :catalog_number, :matrix)
+             :catalog_number, :matrix, :label)
         ON CONFLICT (discogs_release_id)
         WHERE discogs_release_id IS NOT NULL
         DO UPDATE SET
@@ -41,7 +41,8 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             year                 = EXCLUDED.year,
             country              = EXCLUDED.country,
             catalog_number       = COALESCE(EXCLUDED.catalog_number, pressing.catalog_number),
-            matrix               = COALESCE(EXCLUDED.matrix, pressing.matrix)
+            matrix               = COALESCE(EXCLUDED.matrix, pressing.matrix),
+            label                = COALESCE(EXCLUDED.label, pressing.label)
         RETURNING id
         """
     )
@@ -56,6 +57,7 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             "country": pressing_in.country,
             "catalog_number": pressing_in.catalog_number,
             "matrix": pressing_in.matrix,
+            "label": pressing_in.label,
         },
     )
     return row.scalar_one()

--- a/app/services/pressing.py
+++ b/app/services/pressing.py
@@ -42,7 +42,7 @@ def upsert_pressing(db: Session, pressing_in: DiscogsPressingIn) -> uuid.UUID:
             country              = EXCLUDED.country,
             catalog_number       = COALESCE(EXCLUDED.catalog_number, pressing.catalog_number),
             matrix               = COALESCE(EXCLUDED.matrix, pressing.matrix),
-            label                = COALESCE(EXCLUDED.label, pressing.label)
+            label                = COALESCE(pressing.label, EXCLUDED.label)
         RETURNING id
         """
     )

--- a/docs/design-discogs.md
+++ b/docs/design-discogs.md
@@ -78,7 +78,10 @@ CREATE TABLE pressing (
   title                TEXT,
   artists_sort         TEXT,
   year                 INTEGER,
-  country              TEXT
+  country              TEXT,
+  catalog_number       TEXT,   -- added migration 346f77d5b693
+  matrix               TEXT,   -- added migration 346f77d5b693
+  label                TEXT    -- added migration 4b7ab0a331c0
 );
 
 -- Partial unique index: enforce uniqueness only when discogs_release_id is set
@@ -116,8 +119,13 @@ Only the fields stored in the lean `pressing` bookmark are listed. All other Dis
 | `artists_sort`     | `pressing.artists_sort`       | Search/sort                    |
 | `year`             | `pressing.year`               | Numeric year                   |
 | `country`          | `pressing.country`            | Country facet                  |
+| `catno` (search result) / `labels[].catno` (release) | `pressing.catalog_number` | First catalog number; local wins on conflict |
+| `identifiers[]` where `type = 'Matrix / Runout'` | `pressing.matrix` | Sides joined with ` / `; local wins on conflict |
+| `label[]` (search result) / `labels[].name` (release) | `pressing.label` | First label name; local wins on conflict |
 
-All other Discogs fields (including `master_id`, `released`, `released_formatted`, `status`, `data_quality`, market signals, community signals, tracks, images, credits, labels, identifiers) are fetched on demand and returned to the client without local persistence.
+All other Discogs fields (including `master_id`, `released`, `released_formatted`, `status`, `data_quality`, market signals, community signals, tracks, images, credits, full labels array, full identifiers array) are fetched on demand and returned to the client without local persistence.
+
+**Local database precedence:** When a local `pressing` row already holds a non-null value for any field, a re-acquire supplying a different Discogs value does not overwrite it. The upsert uses `COALESCE(pressing.<col>, EXCLUDED.<col>)` so only NULL fields are filled in. See [design.md](design.md) for the full decision record.
 
 ### Data Quality and Normalization Notes
 
@@ -138,7 +146,7 @@ This is the primary integration path. It is user-triggered and synchronous.
 2. The backend calls the Discogs release search API and returns paginated candidate pressings (`GET /discogs/releases?q=...`).
 3. User selects a pressing from the results.
 4. The backend fetches the full release payload for the selected `discogs_release_id` from Discogs, using `discogs_resource_url` as the source pointer.
-5. Upsert `pressing` by `discogs_release_id`, persisting only the eight lean columns.
+5. Upsert `pressing` by `discogs_release_id`, persisting the lean bookmark columns. Existing non-null values are never overwritten (local database precedence).
 6. Link the upserted `pressing_id` to the `inventory_item` on acquire or patch.
 7. Detailed release data (tracks, images, credits, market signals, etc.) is returned to the client for display only and is not written to the database.
 

--- a/docs/design-discogs.md
+++ b/docs/design-discogs.md
@@ -119,7 +119,7 @@ Only the fields stored in the lean `pressing` bookmark are listed. All other Dis
 | `artists_sort`     | `pressing.artists_sort`       | Search/sort                    |
 | `year`             | `pressing.year`               | Numeric year                   |
 | `country`          | `pressing.country`            | Country facet                  |
-| `catno` (search result) / `labels[].catno` (release) | `pressing.catalog_number` | First catalog number; local wins on conflict |
+| `catno` (search result) | `pressing.catalog_number` | Catalog number at acquire time; the release fetch does not currently backfill this field; local wins on re-acquire conflict |
 | `identifiers[]` where `type = 'Matrix / Runout'` | `pressing.matrix` | Sides joined with ` / `; local wins on conflict |
 | `label[]` (search result) / `labels[].name` (release) | `pressing.label` | First label name; local wins on conflict |
 

--- a/docs/design-import.md
+++ b/docs/design-import.md
@@ -74,7 +74,8 @@ Pass A: metadata and pressing resolution
 
 - Prefer `Discogs#` as external identity key when present
 - Map metadata into `pressing` (title, artists_sort, year, country)
-- Label, catalog number, and full artist text are not stored in `pressing`; they are available on demand from the Discogs API for linked releases, and are preserved in import metadata for traceability
+- Label is stored in `pressing.label` (first label name from Discogs at acquire time); catalog number is stored in `pressing.catalog_number`. Both are nullable and populated on-demand when a Discogs release is linked. Legacy rows without a Discogs link will have NULL.
+- Full artist text is not stored in `pressing`; it is available on demand from the Discogs API for linked releases and is preserved in import metadata for traceability
 - Retain legacy-only fields in import metadata for traceability
 
 Pass B: inventory item and transaction creation
@@ -92,8 +93,8 @@ Pass B: inventory item and transaction creation
 | Artist | `pressing.artists_sort` (sort key); raw Access Artist text preserved in import metadata | `pressing.artists_sort` is a normalized sort key, not the raw source text; canonical artist normalization is a later phase |
 | ArtistSort | `pressing.artists_sort` | preferred sort key |
 | Title | `pressing.title` | required for canonical display |
-| Label | available on demand from Discogs API (`labels[]` in release payload) | not stored locally; fetched via proxy endpoint when needed |
-| Number | available on demand from Discogs API (`labels[].catno` in release payload) | not stored locally; fetched via proxy endpoint when needed |
+| Label | `pressing.label` (first label name at acquire time) | Populated from Discogs `label[]` (search result) or `labels[].name` (release payload); local value wins on re-acquire conflict |
+| Number | `pressing.catalog_number` (catalog number at acquire time) | Populated from Discogs `catno` (search result) or `labels[].catno` (release payload); local value wins on re-acquire conflict |
 | Discogs# | `pressing.discogs_release_id` | primary external key if valid |
 | Year | `pressing.year` | integer coercion with validation |
 | Value | import transaction metadata | estimated value, not guaranteed cost basis |
@@ -154,7 +155,7 @@ Vinyl record identification has no industry standard. Record companies, labels, 
 - Identifies the mastering engineer or mastering house responsible for that side.
 - May incorporate part or all of the catalog number as a prefix or suffix.
 - Because matrix numbers are per-side, a single release has at least two distinct matrix values (Side A, Side B). Box sets may have many more.
-- Discogs surfaces matrix numbers via `identifiers[]` in the release payload (type `'Matrix / Runout'`). This data is available on demand from the Discogs API via the proxy endpoint and is not stored locally.
+- Discogs surfaces matrix numbers via `identifiers[]` in the release payload (type `'Matrix / Runout'`). Matrix is persisted locally in `pressing.matrix` (sides joined with ` / `) at acquire time.
 
 ### Catalog Numbers
 
@@ -162,10 +163,10 @@ Vinyl record identification has no industry standard. Record companies, labels, 
 - Typically appears on the cover and/or the record label.
 - The "record number" is often the catalog number, but not always — the terms overlap without being interchangeable.
 - Box sets frequently carry a separate catalog number for the overall set **and** distinct numbers for each individual disc inside. This relationship is not guaranteed and cannot be assumed.
-- Catalog number and label data are available on demand from the Discogs API via the proxy endpoint (`labels[]` in the release payload) and are not stored locally.
+- Catalog number is persisted locally in `pressing.catalog_number` from the Discogs `catno` field at acquire time. The full `labels[]` array (with all catalog numbers per label) remains available on demand from the proxy endpoint.
 
 ### Modeling Rationale
 
-The heterogeneity of real-world vinyl data is why identifier and label data are not forced into a single canonical local field. Discogs surfaces this complexity via `identifiers[]` and `labels[]` in the full release payload, which is available on demand from the proxy endpoint. The lean local schema (`pressing`) does not store this data; it is fetched when the user explicitly requests release detail.
+The heterogeneity of real-world vinyl data is why identifier and label data are not forced into a complex normalized local structure. Only the primary display value (first label name, first catalog number, joined matrix) is persisted locally. The full detail — `identifiers[]` and `labels[]` — is available on demand from the proxy endpoint when the user explicitly requests release detail.
 
 Do not attempt to enforce a single canonical "the catalog number" field at the pressing level. The reality is one pressing may have multiple catalog number representations across different labels and formats, and that is correct data.

--- a/docs/design-import.md
+++ b/docs/design-import.md
@@ -74,7 +74,7 @@ Pass A: metadata and pressing resolution
 
 - Prefer `Discogs#` as external identity key when present
 - Map metadata into `pressing` (title, artists_sort, year, country)
-- Label is stored in `pressing.label` (first label name from Discogs at acquire time); catalog number is stored in `pressing.catalog_number`. Both are nullable and populated on-demand when a Discogs release is linked. Legacy rows without a Discogs link will have NULL.
+- Label is stored in `pressing.label` (first label name); sourced from `label[0]` in the Discogs search result and optionally refined from `labels[0].name` via the full release fetch. Catalog number is stored in `pressing.catalog_number`; sourced from `catno` in the search result — the release fetch does not currently backfill `catalog_number`. Both fields are nullable; legacy rows without a Discogs link will have NULL.
 - Full artist text is not stored in `pressing`; it is available on demand from the Discogs API for linked releases and is preserved in import metadata for traceability
 - Retain legacy-only fields in import metadata for traceability
 
@@ -94,7 +94,7 @@ Pass B: inventory item and transaction creation
 | ArtistSort | `pressing.artists_sort` | preferred sort key |
 | Title | `pressing.title` | required for canonical display |
 | Label | `pressing.label` (first label name at acquire time) | Populated from Discogs `label[]` (search result) or `labels[].name` (release payload); local value wins on re-acquire conflict |
-| Number | `pressing.catalog_number` (catalog number at acquire time) | Populated from Discogs `catno` (search result) or `labels[].catno` (release payload); local value wins on re-acquire conflict |
+| Number | `pressing.catalog_number` (catalog number at acquire time) | Populated from Discogs `catno` (search result only); the release fetch does not currently backfill this field; local value wins on re-acquire conflict |
 | Discogs# | `pressing.discogs_release_id` | primary external key if valid |
 | Year | `pressing.year` | integer coercion with validation |
 | Value | import transaction metadata | estimated value, not guaranteed cost basis |

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,7 +21,7 @@ Operational profile assumptions:
 
 ### Discogs Integration: Lean Schema and On-Demand Fetches (April 2026)
 
-**Decision:** `pressing` stores a lean eight-column bookmark (id, created_at, discogs_release_id, discogs_resource_url, title, artists_sort, year, country). All Discogs detail data — tracks, images, credits, labels, identifiers, market signals, community signals, raw payload — is fetched on demand via a proxy endpoint and is never stored locally.
+**Decision:** `pressing` stores a lean bookmark (id, created_at, discogs_release_id, discogs_resource_url, title, artists_sort, year, country, catalog_number, matrix, label). All Discogs detail data — tracks, images, credits, identifiers beyond matrix, market signals, community signals, raw payload — is fetched on demand via a proxy endpoint and is never stored locally.
 
 **Rationale:**
 
@@ -38,6 +38,16 @@ Operational profile assumptions:
 - Market signals are displayed in the release detail panel on user request; they are not shown in list views.
 
 See [design-discogs.md](design-discogs.md) for full integration design.
+
+### Local Database Precedence over Discogs (April 2026)
+
+**Decision:** When a local `pressing` row already holds a non-null value for any field, a subsequent acquire or re-link that supplies a different value from Discogs does **not** overwrite it. The local database always takes precedence over Discogs.
+
+**Rationale:**
+
+- A user or operator may have manually corrected a field (e.g. label, catalog number) that Discogs has wrong or ambiguous. Silent overwrites would destroy that correction without any audit trail.
+- Discogs data can change between the first acquire and a re-acquire; the local record reflects the owner's understanding of the pressing, which is more authoritative for this use case than the current Discogs state.
+- COALESCE order in `upsert_pressing`: `COALESCE(pressing.<col>, EXCLUDED.<col>)` — existing value wins; only NULL fields are filled in from the incoming record.
 
 ---
 

--- a/migrations/versions/4b7ab0a331c0_add_label_to_pressing.py
+++ b/migrations/versions/4b7ab0a331c0_add_label_to_pressing.py
@@ -6,11 +6,19 @@ Create Date: 2026-04-12
 
 Schema notes:
 - label: the primary record label name for this pressing, sourced from the
-  Discogs search result (labels[].name) or the full release response
-  (labels[].name) at acquire time.  Stored as a single TEXT value; where a
-  pressing carries multiple labels only the first is persisted, which covers
-  the primary attribution for display purposes.  Nullable: not all releases
-  carry explicit label data, and legacy pressing rows pre-date this column.
+  Discogs search result (`label[]`, a flat string array) or the full release
+  response (`labels[].name`, an array of objects) at acquire time.  Stored as
+  a single TEXT value; where a pressing carries multiple labels only the first
+  is persisted, which covers the primary attribution for display purposes.
+  Nullable: not all releases carry explicit label data, and legacy pressing
+  rows pre-date this column.
+
+Conflict behaviour:
+  On re-acquire of an already-linked pressing the upsert uses
+  COALESCE(pressing.label, EXCLUDED.label) — the existing local value wins
+  over any incoming Discogs value.  Only a NULL local field is filled in.
+  This matches the project-wide "local database takes precedence" decision;
+  see docs/design.md.
 
 Column is TEXT NULLABLE with no index — display-only field, not filtered or
 sorted.

--- a/migrations/versions/4b7ab0a331c0_add_label_to_pressing.py
+++ b/migrations/versions/4b7ab0a331c0_add_label_to_pressing.py
@@ -1,0 +1,38 @@
+"""Add label column to pressing
+
+Revision ID: 4b7ab0a331c0
+Revises: 346f77d5b693
+Create Date: 2026-04-12
+
+Schema notes:
+- label: the primary record label name for this pressing, sourced from the
+  Discogs search result (labels[].name) or the full release response
+  (labels[].name) at acquire time.  Stored as a single TEXT value; where a
+  pressing carries multiple labels only the first is persisted, which covers
+  the primary attribution for display purposes.  Nullable: not all releases
+  carry explicit label data, and legacy pressing rows pre-date this column.
+
+Column is TEXT NULLABLE with no index — display-only field, not filtered or
+sorted.
+
+Rollback intent:
+  Drop the column.  Any label values written after this migration will be lost
+  on downgrade; pre-existing pressing data is unaffected.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "4b7ab0a331c0"  # pragma: allowlist secret
+down_revision = "346f77d5b693"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pressing", sa.Column("label", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pressing", "label")

--- a/tests/test_inventory_api.py
+++ b/tests/test_inventory_api.py
@@ -798,6 +798,7 @@ class TestPressingService:
             country="UK",
             catalog_number="RCA PB 9693",
             matrix="YEX 773-1 HAGG",
+            label="RCA",
         )
 
     def test_upsert_pressing_executes_insert_on_conflict(self) -> None:
@@ -837,6 +838,35 @@ class TestPressingService:
         assert params["country"] == pressing_in.country
         assert params["catalog_number"] == pressing_in.catalog_number
         assert params["matrix"] == pressing_in.matrix
+        assert params["label"] == pressing_in.label
+
+    def test_upsert_conflict_coalesce_order_prefers_local(self) -> None:
+        """ON CONFLICT clause must use COALESCE(pressing.<col>, EXCLUDED.<col>) for
+        every updatable field so that a non-null local value is never overwritten
+        by a re-acquire from Discogs.  COALESCE(EXCLUDED.<col>, pressing.<col>)
+        would silently reverse the precedence rule."""
+        from app.services.pressing import upsert_pressing
+
+        db = MagicMock()
+        db.execute.return_value.scalar_one.return_value = uuid.uuid4()
+        upsert_pressing(db, self._make_pressing_in())
+
+        stmt_text = str(db.execute.call_args.args[0])
+        updatable_cols = [
+            "discogs_resource_url",
+            "title",
+            "artists_sort",
+            "year",
+            "country",
+            "catalog_number",
+            "matrix",
+            "label",
+        ]
+        for col in updatable_cols:
+            assert f"COALESCE(pressing.{col}, EXCLUDED.{col})" in stmt_text, (
+                f"Expected COALESCE(pressing.{col}, EXCLUDED.{col}) in ON CONFLICT "
+                f"clause; local-wins precedence rule violated for column '{col}'"
+            )
 
     def test_upsert_pressing_returns_scalar_uuid(self) -> None:
         """upsert_pressing() propagates scalar_one() directly to the caller."""

--- a/tests/test_pressing_models.py
+++ b/tests/test_pressing_models.py
@@ -96,6 +96,7 @@ class TestPressingColumns:
         nullable_cols = [
             "discogs_release_id", "discogs_resource_url",
             "title", "artists_sort", "year", "country",
+            "catalog_number", "matrix", "label",
         ]
         for col_name in nullable_cols:
             assert _col(self.t, col_name).nullable, f"{col_name} should be nullable"

--- a/tests/test_pressing_models.py
+++ b/tests/test_pressing_models.py
@@ -100,6 +100,12 @@ class TestPressingColumns:
         for col_name in nullable_cols:
             assert _col(self.t, col_name).nullable, f"{col_name} should be nullable"
 
+    def test_label_column_present(self) -> None:
+        assert "label" in self.t.c
+
+    def test_label_column_nullable(self) -> None:
+        assert _col(self.t, "label").nullable
+
 
 # ---------------------------------------------------------------------------
 # inventory_item Phase A additions

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -19,5 +19,12 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -376,6 +376,14 @@ table.discogs-results thead th {
   background: var(--color-badge-distribution-hover-bg);
 }
 
+/* Detail and edit panels inside a collection tile inherit the tint */
+.inventory-item.item-private .item-detail-panel,
+.inventory-item.item-public .item-detail-panel,
+.inventory-item.item-private .edit-item-panel,
+.inventory-item.item-public .edit-item-panel {
+  background: transparent;
+}
+
 /* Screen-reader-only utility — visually hidden, available to AT */
 .sr-only {
   position: absolute;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -352,13 +352,15 @@ table.discogs-results thead th {
   text-transform: capitalize;
 }
 
-/* Collection-type color accent on tile left edge */
+/* Collection-type color accent — full tile tint */
 .inventory-item.item-private {
-  border-left: 3px solid var(--color-badge-personal-text);
+  background: var(--color-badge-personal-bg);
+  border-color: var(--color-badge-personal-text);
 }
 
 .inventory-item.item-public {
-  border-left: 3px solid var(--color-badge-distribution-text);
+  background: var(--color-badge-distribution-bg);
+  border-color: var(--color-badge-distribution-text);
 }
 
 /* Screen-reader-only utility — visually hidden, available to AT */

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -363,6 +363,19 @@ table.discogs-results thead th {
   border-color: var(--color-badge-distribution-text);
 }
 
+/* Preserve collection tint through hover/focus/active on the inner row */
+.inventory-item.item-private .item-row:hover,
+.inventory-item.item-private .item-row:focus-visible,
+.inventory-item.item-private .item-row.item-row-active {
+  background: var(--color-badge-personal-hover-bg);
+}
+
+.inventory-item.item-public .item-row:hover,
+.inventory-item.item-public .item-row:focus-visible,
+.inventory-item.item-public .item-row.item-row-active {
+  background: var(--color-badge-distribution-hover-bg);
+}
+
 /* Screen-reader-only utility — visually hidden, available to AT */
 .sr-only {
   position: absolute;

--- a/ui/src/api/inventory.test.ts
+++ b/ui/src/api/inventory.test.ts
@@ -165,6 +165,7 @@ describe('updateItem', () => {
       country: 'UK',
       catalog_number: null,
       matrix: null,
+      label: null,
     }
     await updateItem('item-1', { pressing })
     const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]

--- a/ui/src/api/inventory.ts
+++ b/ui/src/api/inventory.ts
@@ -10,6 +10,7 @@ export interface PressingBookmark {
   country: string | null
   catalog_number: string | null
   matrix: string | null
+  label: string | null
 }
 
 export interface InventoryItem {
@@ -42,6 +43,7 @@ export interface DiscogsPressingIn {
   country: string | null
   catalog_number: string | null
   matrix: string | null
+  label: string | null
 }
 
 export interface AcquireRequest {

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -39,6 +39,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   function handleDiscogsQueryChange(q: string) {
     setDiscogsQuery(q)
     setSelectedPressing(null)
+    matrixFetch.current = null   // cancel any in-flight fetch for the old selection
     setDiscogsError(null)
     if (searchTimer.current) clearTimeout(searchTimer.current)
     const seq = ++searchSeq.current
@@ -125,7 +126,12 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
       if (matrixFetch.current) {
         const patched = await matrixFetch.current
         matrixFetch.current = null
-        if (patched) pressingForSave = patched
+        // Only use the patched value when the selection hasn't changed since the
+        // fetch was kicked off: guard against the user clearing/changing the
+        // selection while the Discogs fetch was in flight.
+        if (patched && selectedPressing && patched.discogs_release_id === selectedPressing.discogs_release_id) {
+          pressingForSave = patched
+        }
       }
       const request: UpdateRequest = {
         ...(pressingForSave ? { pressing: pressingForSave } : {}),

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -77,6 +77,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
       country: result.country ?? null,
       catalog_number: result.catno ?? null,
       matrix: null,
+      label: result.label?.[0] ?? null,
     }
     setSelectedPressing(pressing)
     setDiscogsResults([])
@@ -91,9 +92,12 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           ?.filter(i => i.type === 'Matrix / Runout')
           .map(i => i.value)
           .join(' / ') || null
-        if (matrix && isMounted.current) {
+        const label = release.labels?.[0]?.name ?? null
+        if ((matrix || label) && isMounted.current) {
           setSelectedPressing(p =>
-            p && p.discogs_release_id === releaseId ? { ...p, matrix } : p
+            p && p.discogs_release_id === releaseId
+              ? { ...p, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) }
+              : p
           )
         }
       })

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -94,16 +94,17 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           .join(' / ') || null
         const label = release.labels?.[0]?.name ?? null
         if ((matrix || label) && isMounted.current) {
-          // Resolve the promise to the patched pressing so handleSave can read
-          // it directly instead of relying on async setState having settled.
-          let patched: DiscogsPressingIn | null = null
-          setSelectedPressing(p => {
-            if (p && p.discogs_release_id === releaseId) {
-              patched = { ...p, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) }
-              return patched
-            }
-            return p
-          })
+          // Compute patched pressing synchronously from the known closure value
+          // so the promise resolves to a reliable result regardless of when
+          // React schedules the functional updater below.
+          const patched: DiscogsPressingIn = {
+            ...pressing,
+            ...(matrix != null ? { matrix } : {}),
+            ...(label != null ? { label } : {}),
+          }
+          setSelectedPressing(p =>
+            p && p.discogs_release_id === releaseId ? patched : p
+          )
           return patched
         }
         return null

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -202,6 +202,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
             aria-label="Clear selected pressing"
             onClick={() => {
               setSelectedPressing(null)
+              matrixFetch.current = null
               setDiscogsQuery(item.pressing?.title ?? '')
             }}
           >

--- a/ui/src/components/EditItemPanel.tsx
+++ b/ui/src/components/EditItemPanel.tsx
@@ -23,7 +23,7 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const searchSeq = useRef(0)
   const isMounted = useRef(true)
-  const matrixFetch = useRef<Promise<void> | null>(null)
+  const matrixFetch = useRef<Promise<DiscogsPressingIn | null> | null>(null)
 
   useEffect(() => {
     return () => {
@@ -94,14 +94,21 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
           .join(' / ') || null
         const label = release.labels?.[0]?.name ?? null
         if ((matrix || label) && isMounted.current) {
-          setSelectedPressing(p =>
-            p && p.discogs_release_id === releaseId
-              ? { ...p, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) }
-              : p
-          )
+          // Resolve the promise to the patched pressing so handleSave can read
+          // it directly instead of relying on async setState having settled.
+          let patched: DiscogsPressingIn | null = null
+          setSelectedPressing(p => {
+            if (p && p.discogs_release_id === releaseId) {
+              patched = { ...p, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) }
+              return patched
+            }
+            return p
+          })
+          return patched
         }
+        return null
       })
-      .catch(() => { /* matrix stays null — non-critical */ })
+      .catch(() => null) // matrix/label stays null — non-critical
   }
 
   async function handleSave() {
@@ -110,13 +117,17 @@ export function EditItemPanel({ item, onSave, onCancel }: Props) {
     setSaveError(null)
     try {
       // Await any in-flight matrix fetch so the pressing payload includes matrix
-      // if the user saves before the best-effort detail request has resolved.
+      // and label if the user saves before the best-effort detail request resolves.
+      // The promise resolves to the patched DiscogsPressingIn (or null), giving us
+      // the settled value without relying on React setState having committed yet.
+      let pressingForSave = selectedPressing
       if (matrixFetch.current) {
-        await matrixFetch.current
+        const patched = await matrixFetch.current
         matrixFetch.current = null
+        if (patched) pressingForSave = patched
       }
       const request: UpdateRequest = {
-        ...(selectedPressing ? { pressing: selectedPressing } : {}),
+        ...(pressingForSave ? { pressing: pressingForSave } : {}),
         condition_media: conditionMedia || null,
         condition_sleeve: conditionSleeve || null,
         notes: notes || null,

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -22,8 +22,10 @@
 
   --color-badge-personal-bg: #dbeafe;
   --color-badge-personal-text: #1d4ed8;
+  --color-badge-personal-hover-bg: #bfdbfe;
   --color-badge-distribution-bg: #d1fae5;
   --color-badge-distribution-text: #065f46;
+  --color-badge-distribution-hover-bg: #a7f3d0;
 
   --color-row-hover-bg: #eff6ff;
   --color-row-hover-text: #1d4ed8;
@@ -59,8 +61,10 @@
 
     --color-badge-personal-bg: #1e3a5f;
     --color-badge-personal-text: #93c5fd;
+    --color-badge-personal-hover-bg: #253f70;
     --color-badge-distribution-bg: #064e3b;
     --color-badge-distribution-text: #6ee7b7;
+    --color-badge-distribution-hover-bg: #076652;
 
     --color-row-hover-bg: #1e3a5f;
     --color-row-hover-text: #93c5fd;

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -238,6 +238,7 @@ const sampleDiscogsResult = {
   country: 'UK',
   resource_url: 'https://api.discogs.com/releases/249504',
   catno: 'RCA PB 9693',
+  label: ['RCA'],
 }
 
 async function openAcquireForm() {
@@ -289,6 +290,7 @@ describe('InventoryPage — Discogs search-and-select', () => {
     expect(req.pressing?.discogs_release_id).toBe(249504)
     expect(req.pressing?.title).toBe('Never Gonna Give You Up')
     expect(req.pressing?.catalog_number).toBe('RCA PB 9693')
+    expect(req.pressing?.label).toBe('RCA')
   })
 
   it('editing the search query after selection removes pressing from the acquire request', async () => {
@@ -375,6 +377,37 @@ describe('InventoryPage — Discogs search-and-select', () => {
     await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())
     const req = mockAcquireItems.mock.calls[0][0]
     expect(req.pressing?.matrix).toBe('YEX 773-1 HAGG / YEX 774-1 HAGG')
+  })
+
+  it('populates label on the acquire request when getDiscogsRelease resolves with labels', async () => {
+    mockSearchDiscogs.mockResolvedValue({
+      results: [{ ...sampleDiscogsResult, label: undefined }],
+      pagination: { page: 1, pages: 1, per_page: 50, items: 1, urls: {} },
+    })
+    let resolveRelease!: (v: Awaited<ReturnType<typeof discogsApi.getDiscogsRelease>>) => void
+    mockGetDiscogsRelease.mockReturnValue(
+      new Promise(res => { resolveRelease = res }),
+    )
+    await openAcquireForm()
+    const user = userEvent.setup()
+    await user.type(screen.getByPlaceholderText('Artist, title, label\u2026'), 'Rick')
+    await waitFor(() =>
+      expect(screen.getByText('Never Gonna Give You Up')).toBeInTheDocument(),
+      { timeout: 1500 },
+    )
+    await user.click(screen.getByText('Never Gonna Give You Up'))
+    await act(async () => {
+      resolveRelease({
+        id: 249504,
+        title: 'Never Gonna Give You Up',
+        identifiers: [],
+        labels: [{ name: 'Parlophone' }],
+      })
+    })
+    await user.click(screen.getByText('Confirm'))
+    await waitFor(() => expect(mockAcquireItems).toHaveBeenCalledOnce())
+    const req = mockAcquireItems.mock.calls[0][0]
+    expect(req.pressing?.label).toBe('Parlophone')
   })
 
   it('acquire proceeds with matrix null when getDiscogsRelease rejects', async () => {
@@ -484,6 +517,7 @@ const pressingRick = {
   country: 'UK',
   catalog_number: 'RCA PB 9693',
   matrix: null,
+  label: 'RCA',
 }
 
 const pressingNew = {
@@ -496,6 +530,7 @@ const pressingNew = {
   country: 'UK',
   catalog_number: 'FAC 73',
   matrix: null,
+  label: null,
 }
 
 const itemRick = { ...sampleItem, id: 'item-rick', pressing_id: 'pressing-rick', pressing: pressingRick }
@@ -636,5 +671,19 @@ describe('InventoryPage — item detail panel Discogs data', () => {
     // Wait for the Discogs data section and assert label is rendered
     await waitFor(() => expect(screen.getByText('RCA')).toBeInTheDocument())
     expect(screen.getByText('Label')).toBeInTheDocument()
+  })
+
+  it('renders pressing label in the inventory list row when label is set', async () => {
+    const itemWithLabel = {
+      ...sampleItem,
+      id: 'item-label-row',
+      pressing_id: 'pressing-rick',
+      pressing: { ...pressingRick, label: 'RCA' },
+    }
+    mockListItems.mockResolvedValue([itemWithLabel])
+    mockGetSummary.mockResolvedValue(filledSummary)
+    renderPage()
+    await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
+    expect(screen.getByText(/RCA/)).toBeInTheDocument()
   })
 })

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -674,16 +674,17 @@ describe('InventoryPage — item detail panel Discogs data', () => {
   })
 
   it('renders pressing label in the inventory list row when label is set', async () => {
+    const uniqueLabel = 'Blue Note Records'
     const itemWithLabel = {
       ...sampleItem,
       id: 'item-label-row',
       pressing_id: 'pressing-rick',
-      pressing: { ...pressingRick, label: 'RCA' },
+      pressing: { ...pressingRick, catalog_number: null, label: uniqueLabel },
     }
     mockListItems.mockResolvedValue([itemWithLabel])
     mockGetSummary.mockResolvedValue(filledSummary)
     renderPage()
     await waitFor(() => screen.getByText(/Never Gonna Give You Up/))
-    expect(screen.getByText(/RCA/)).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(uniqueLabel))).toBeInTheDocument()
   })
 })

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -203,11 +203,13 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
         const label = release.labels?.[0]?.name ?? null
         if (matrix || label) {
           setSelectedPressing(p =>
-            p && p.discogs_release_id === releaseId ? { ...p, matrix, label } : p
+            p && p.discogs_release_id === releaseId
+              ? { ...p, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) }
+              : p
           )
           setAcquireForm(f =>
             f.pressing && f.pressing.discogs_release_id === releaseId
-              ? { ...f, pressing: { ...f.pressing, matrix, label } }
+              ? { ...f, pressing: { ...f.pressing, ...(matrix != null ? { matrix } : {}), ...(label != null ? { label } : {}) } }
               : f
           )
         }

--- a/ui/src/pages/InventoryPage.tsx
+++ b/ui/src/pages/InventoryPage.tsx
@@ -183,6 +183,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
       country: result.country ?? null,
       catalog_number: result.catno ?? null,
       matrix: null,
+      label: result.label?.[0] ?? null,
     }
     setSelectedPressing(pressing)
     setAcquireForm(f => ({ ...f, pressing }))
@@ -199,13 +200,14 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
           ?.filter(i => i.type === 'Matrix / Runout')
           .map(i => i.value)
           .join(' / ') || null
-        if (matrix) {
+        const label = release.labels?.[0]?.name ?? null
+        if (matrix || label) {
           setSelectedPressing(p =>
-            p && p.discogs_release_id === releaseId ? { ...p, matrix } : p
+            p && p.discogs_release_id === releaseId ? { ...p, matrix, label } : p
           )
           setAcquireForm(f =>
             f.pressing && f.pressing.discogs_release_id === releaseId
-              ? { ...f, pressing: { ...f.pressing, matrix } }
+              ? { ...f, pressing: { ...f.pressing, matrix, label } }
               : f
           )
         }
@@ -512,6 +514,7 @@ export function InventoryPage({ user, signOut }: InventoryPageProps) {
                         {item.pressing.year != null && ` (${item.pressing.year})`}
                         {item.pressing.country && ` · ${item.pressing.country}`}
                         {item.pressing.catalog_number && ` · ${item.pressing.catalog_number}`}
+                        {item.pressing.label && ` · ${item.pressing.label}`}
                       </span>
                     )}
                     {item.condition_media && (


### PR DESCRIPTION
## Summary

Two inventory UX fixes and a new label field on the pressing bookmark.

### Fix: full-tile collection color

The collection-type color accent was only showing as a 3px left border. Replaced with a full tile background tint (`--color-badge-*-bg`) and matching border color so the entire tile carries the collection color.

### Feat: label field on pressing

Adds a `label` (record label name) column to the `pressing` table and surfaces it everywhere:

- **Migration** `4b7ab0a331c0` — TEXT NULLABLE, `down_revision: 346f77d5b693`
- **Backend** — Pressing model, `DiscogsPressingIn` schema, `PressingResponse` schema, `upsert_pressing` service (INSERT + ON CONFLICT DO UPDATE with COALESCE)
- **Frontend** — `PressingBookmark` and `DiscogsPressingIn` TS interfaces; acquire flow populates label from search result `labels[0]` and refines it from the full release fetch alongside matrix; list row renders label after catalog number when present

## Why

- Tile colors were barely visible as a thin left border — the intent was a full-tile tint.
- Label is one of the most identifying fields for a pressing and was only available in the detail popup (fetched on-demand from Discogs). Storing it locally on the pressing bookmark makes it available in the list without additional API calls.

## Validation

- 50 frontend tests passing (2 new: label from search result in acquire request; label in list row)
- 177 backend tests passing (2 new: `label` column present and nullable)
- Pre-commit hooks passing on all 3 commits

## Risks and follow-ups

- Existing pressing rows will have `label = NULL` until they are re-acquired or updated — no backfill. This is consistent with how `matrix` was handled.
- A Phase 4 migration deploy is required before the new `label` column is available in production.
