### PR TITLE
fix: merge migration heads (add_label + rename_collection_types)

### DIFF
--- a/migrations/versions/09af90c563da_merge_add_label_and_rename_collection_.py
+++ b/migrations/versions/09af90c563da_merge_add_label_and_rename_collection_.py
@@ -1,0 +1,26 @@
+"""merge add_label and rename_collection_types heads
+
+Revision ID: 09af90c563da
+Revises: 4b7ab0a331c0, e3b7a91f2c84
+Create Date: 2026-04-12 21:53:07.878443
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '09af90c563da'  # pragma: allowlist secret
+down_revision: Union[str, None] = ('4b7ab0a331c0', 'e3b7a91f2c84')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/migrations/versions/09af90c563da_merge_add_label_and_rename_collection_.py
+++ b/migrations/versions/09af90c563da_merge_add_label_and_rename_collection_.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '09af90c563da'  # pragma: allowlist secret
-down_revision: Union[str, None] = ('4b7ab0a331c0', 'e3b7a91f2c84')
+down_revision: Union[str, None] = ('4b7ab0a331c0', 'e3b7a91f2c84')  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

Creates a merge migration (`09af90c563da`) to unify two diverged heads that both branched from `346f77d5b693`:

- `4b7ab0a331c0` — add_label_to_pressing (PR #70)
- `e3b7a91f2c84` — rename_collection_types_private_public

Both revisions set `down_revision = '346f77d5b693'`, creating a two-head state that blocks `alembic upgrade head`.

## Why

The deploy of PR #70 failed with:

```
FAILED: Multiple head revisions are present for given argument 'head'
```

Alembic requires a single linear head for `upgrade head` to work. This merge migration is the standard resolution — it has an empty upgrade/downgrade body and simply declares both heads as its parents, making `09af90c563da` the new single head.

## Validation performed

- `alembic heads` after merge: `09af90c563da (head)` — single head confirmed
- Merge migration body is empty (no schema changes) — correct for a topology-only merge
- pre-commit checks pass

## Risks and follow-ups

- Low risk: the merge migration carries no DDL
- The migration Lambda (`records-dev-migrate-tmp`) is still running and will be used immediately after merge to apply the full chain (`4b7ab0a331c0` → `09af90c563da`)
- Future migrations must set `down_revision` to `09af90c563da` (the new head), not to either parent branch
