### PR TITLE
feat: show stored label in pressing detail section; neutral panel bg

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -376,12 +376,12 @@ table.discogs-results thead th {
   background: var(--color-badge-distribution-hover-bg);
 }
 
-/* Detail and edit panels inside a collection tile inherit the tint */
+/* Detail and edit panels sit on neutral surface, not the collection tint */
 .inventory-item.item-private .item-detail-panel,
 .inventory-item.item-public .item-detail-panel,
 .inventory-item.item-private .edit-item-panel,
 .inventory-item.item-public .edit-item-panel {
-  background: transparent;
+  background: var(--color-surface);
 }
 
 /* Screen-reader-only utility — visually hidden, available to AT */

--- a/ui/src/components/ItemDetailPanel.tsx
+++ b/ui/src/components/ItemDetailPanel.tsx
@@ -94,6 +94,7 @@ export function ItemDetailPanel({ item, isAdmin, onTransferred, onClose }: Props
             {p.year != null && <><dt>Year</dt><dd>{p.year}</dd></>}
             {p.country && <><dt>Country</dt><dd>{p.country}</dd></>}
             {p.catalog_number && <><dt>Catalog</dt><dd>{p.catalog_number}</dd></>}
+            {p.label && <><dt>Label</dt><dd>{p.label}</dd></>}
             {p.matrix && <><dt>Matrix</dt><dd className="matrix-value">{p.matrix}</dd></>}
           </dl>
         </section>

--- a/ui/src/pages/InventoryPage.test.tsx
+++ b/ui/src/pages/InventoryPage.test.tsx
@@ -653,6 +653,7 @@ describe('InventoryPage — item detail panel Discogs data', () => {
         id: 'pressing-rick',
         discogs_resource_url: null,
         matrix: null,
+        label: null,   // no stored label — only the Discogs section should show RCA
       },
     }
     mockListItems.mockResolvedValue([itemWithPressing])


### PR DESCRIPTION
## Summary

Two UX fixes to the item detail panel.

## Why

1. **Label missing from Pressing section** — `ItemDetailPanel` renders a live Discogs API fetch for the Discogs Data section, which shows label from the release payload. But the stored `pressing.label` (populated at acquire time) was never shown in the Pressing section alongside title, year, country, and catalog. Added `{p.label && <><dt>Label</dt><dd>{p.label}</dd></>}` after catalog_number.

2. **Detail/edit panels inherited collection tile tint** — The panel background was `transparent`, so it showed through the blue/green tile color. Changed to `var(--color-surface)` (neutral grey) so the panel reads as a distinct layer on top of the card.

## Validation performed

- `npm run lint` — passed clean
- `npm test` — 50/50 passed
  - Fixed one test regression: the "renders record label from Discogs release payload" test used `pressingRick` (which has `label: 'RCA'`). With label now rendered in the Pressing section too, `getByText('RCA')` found two elements. Fixed by setting `label: null` on the fixture override — the test is specifically about the Discogs section, not the stored label.

## Risks and follow-ups

- No schema or API changes — pure UI
- The stored `pressing.label` and Discogs release `labels` may differ (stored is first label at acquire time; release may have multiple). No deduplication is applied in the UI — both sections show independently, which is intentional.
